### PR TITLE
Remove call to contextMenu.add()

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -50,5 +50,4 @@ exports.main = function(options, callbacks) {
             if (url) clipboard.set(url);
         }
     });
-    contextMenu.add(item);
 }


### PR DESCRIPTION
This method is no longer used in 0.10pre
