### PR TITLE
hash in the url

### DIFF
--- a/data/js/find-short-url.js
+++ b/data/js/find-short-url.js
@@ -7,7 +7,7 @@ self.on('click', function(node, data) {
     let short = document.querySelector(selectors),
         link;
     if (short && (link = short.href)) {
-        self.postMessage({short: true, url: link});
+        self.postMessage({short: true, url: (link + document.location.hash)});
         return;
     } else {
         // use canonical URL if it exists, current URL otherwise.

--- a/data/js/find-short-url.js
+++ b/data/js/find-short-url.js
@@ -5,15 +5,16 @@ const selectors = 'link[rev=canonical],link[rel=shorturl],link[rel=shortlink]';
 /** Find short URL in the page */
 self.on('click', function(node, data) {
     let short = document.querySelector(selectors),
+        hash = node.hash ? node.hash : '',
         link;
-    if (short && (link = short.href)) {
-        self.postMessage({short: true, url: (link + document.location.hash)});
+    if (short && (link = short.href + hash)) {
+        self.postMessage({short: true, url: link});
         return;
     } else {
         // use canonical URL if it exists, current URL otherwise.
         let canonical = document.querySelector('link[rel=canonical]');
-        if (!(canonical && (link = canonical.href)))
-            link = document.location.href;
+        if (!(canonical && (link = canonical.href + hash)))
+            link = hash ? node.href : document.location.href;
 
         self.postMessage({short: false, url: link});
     }

--- a/data/js/is-permlink-hash.js
+++ b/data/js/is-permlink-hash.js
@@ -1,0 +1,6 @@
+/** Test if anchor is in-page link with hash */
+self.on('context', function(node) {
+    return (node.protocol == document.location.protocol &&
+            node.hostname == document.location.hostname &&
+            node.pathname == document.location.pathname)
+});

--- a/lib/main.js
+++ b/lib/main.js
@@ -34,20 +34,30 @@ exports.main = function(options, callbacks) {
     if (!prefs.has(serviceurl_pref))
         prefs.set(serviceurl_pref, serviceurl_default);
 
+    var onMessage = function(found_url) {
+        let url = found_url['url'];
+
+        if (found_url['short']) {
+            notify("Short URL found:\n" + url);
+        } else {
+            url = createShortUrl(url);
+        }
+        if (url) clipboard.set(url);
+    }
+
     /* Add and hook up context menu */
-    var item = contextMenu.Item({
+    var item_page = contextMenu.Item({
         label: 'Copy ShortURL',
         contentScriptFile: data.url('js/find-short-url.js'),
-        onMessage: function(found_url) {
-            let url = found_url['url'];
+        onMessage: onMessage
+    });
 
-            if (found_url['short']) {
-                notify("Short URL found:\n" + url);
-            } else {
-                url = createShortUrl(url);
-            }
-
-            if (url) clipboard.set(url);
-        }
+    var item_hash = contextMenu.Item({
+        label: 'Copy ShortURL with hash',
+        context: contextMenu.SelectorContext("a[href]"),
+        contentScriptFile: [data.url('js/is-permlink-hash.js'),
+                            data.url('js/find-short-url.js')
+                           ],
+        onMessage: onMessage
     });
 }


### PR DESCRIPTION
Hi,

From original pull request #20

```
Comments on xxx.wordpress.com can be linked directly with a hash in the url,
but the wp.me shorturl is for the blog post only, so I think the hash should
be appended when a pre-defined shorturl is found.
e.g. http://wp.me/pgj4-5Z#comment-4731

About the hash thing, maybe it should only be appended when people right click
a permanent link with a hash? e.g. the date and time corresponding to each
comment on wp.me.
```

These are the two hash related commits.

Thanks.
