### PR TITLE
is.gd use https only now.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ const default_service = 'isgd',
 // variants. Note: Use asynchronous XHR.
 var serviceurls = {
     isgd: {
-        url: 'http://is.gd/api.php?longurl=%URL%'
+        url: 'https://is.gd/api.php?longurl=%URL%'
     },
     tinyurl: {
         url: 'http://tinyurl.com/api-create.php?url=%URL%'

--- a/src/locale/zh-CN.properties
+++ b/src/locale/zh-CN.properties
@@ -1,5 +1,5 @@
 menuitem_label= 复制短网址
-shorten_link_label= Copy ShortURL for this link
+shorten_link_label= 复制这个链接的短网址
 shorten_error= 哦天哪，创建短网址时出错了。
 
 service_title= 网址缩短服务
@@ -9,10 +9,10 @@ customurl_description= 使用 %URL% 作为长网址的占位符
 serviceurl_docs_label= 阅读文档
 serviceurl_docs_title= 关于自定义网址服务的文档
 
-shorten_canonical_title= Shorten canonical URL if longer than
-shorten_canonical_description= Some sites provide canonical "short URLs" aren't short. Use shortening service if they are longer than X characters. (0 = never shorten)
+shorten_canonical_title= 当长度超过多少时缩短URL
+shorten_canonical_description= 一些站点提供的短网址并不短。使用缩短服务，当他们超过X个字符。(0 = 从不缩短)
 
-strip_utm_title= Remove ?utm_* parameters from URL
-strip_utm_description= Marketing campaigns often add unnecessary ?utm_campaign=something tokens to the URL that are safe to remove.
+strip_utm_title= 从URL中移除 ?utm_* 参数
+strip_utm_description= 营销活动经常添加不需要的 ?utm_campaign=something，这些都是可以放心的移除的。
 
-toolbar_button_title= Enable toolbar button
+toolbar_button_title= 启用工具栏按钮

--- a/src/package.json
+++ b/src/package.json
@@ -14,7 +14,7 @@
         "options": [
             {
                 "value": "isgd",
-                "label": "is.gd (http://is.gd/abcde)"
+                "label": "is.gd (https://is.gd/abcde)"
             }, {
                 "value": "tinyurl",
                 "label": "tinyurl.com (http://tinyurl.com/abcde)"


### PR DESCRIPTION
> It does not work on Firefox 48.0.1 and 50.0a2.
> After check, I found that it is the is.gd problem.
> It migrate to HTTPS only, but this addon still use HTTP.
> https://is.gd/news.php

https://addons.mozilla.org/zh-CN/firefox/addon/copy-shorturl/reviews/813813/