### PR TITLE
Feature: Add support for t.ly URL shortener service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@ docs/_templates
 src/dist
 src/node_modules
 src/web-ext-artifacts
+
+.github/copilot-instructions.md
+
+.vscode/mcp.json
+
+src/pnpm-lock.yaml

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "printWidth": 120,
+  "trailingComma": "es5",
+  "arrowParens": "always"
+}

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -1,163 +1,163 @@
 {
-    "extensionDescription": {
-        "message": "Eine Kurz-URL für die aktuelle Seite finden oder erstellen.",
-        "description": ""
-    },
-    "extensionName": {
-        "message": "Copy ShortURL",
-        "description": "name of extension"
-    },
-    "browserAction_label": {
-        "message": "Kurz-URL kopieren",
-        "description": "Toolbar button label text."
-    },
-    "menuitem_label": {
-        "message": "Kurz-URL kopieren",
-        "description": "Context menu item label text for page."
-    },
-    "shorten_link_label": {
-        "message": "Kurz-URL für diesen Link kopieren",
-        "description": "Context menu item label text for link."
-    },
-    "shorten_img_label": {
-        "message": "Kurz-URL für dieses Bild kopieren",
-        "description": "Context menu item label text for image."
-    },
+  "extensionDescription": {
+    "message": "Eine Kurz-URL für die aktuelle Seite finden oder erstellen.",
+    "description": ""
+  },
+  "extensionName": {
+    "message": "Copy ShortURL",
+    "description": "name of extension"
+  },
+  "browserAction_label": {
+    "message": "Kurz-URL kopieren",
+    "description": "Toolbar button label text."
+  },
+  "menuitem_label": {
+    "message": "Kurz-URL kopieren",
+    "description": "Context menu item label text for page."
+  },
+  "shorten_link_label": {
+    "message": "Kurz-URL für diesen Link kopieren",
+    "description": "Context menu item label text for link."
+  },
+  "shorten_img_label": {
+    "message": "Kurz-URL für dieses Bild kopieren",
+    "description": "Context menu item label text for image."
+  },
 
-    "shorten_error": {
-        "message": "Oh-oh, Fehler beim Erstellen der Kurz-URL.",
-        "description": "Error message when shortening URL was unsuccessful."
-    },
-    "apikey_error": {
-        "message": "Kein API key in den Einstellungen.",
-        "description": "Error message when shortening service needs an API key and none was provided."
-    },
-    "error_host_permission": {
-        "message": "Leider funktioniert Copy ShortURL nicht auf Seiten, die der Browser beschränkt.",
-        "description": "Error message when running on about: or addons.mozilla.org."
-    },
+  "shorten_error": {
+    "message": "Oh-oh, Fehler beim Erstellen der Kurz-URL.",
+    "description": "Error message when shortening URL was unsuccessful."
+  },
+  "apikey_error": {
+    "message": "Kein API key in den Einstellungen.",
+    "description": "Error message when shortening service needs an API key and none was provided."
+  },
+  "error_host_permission": {
+    "message": "Leider funktioniert Copy ShortURL nicht auf Seiten, die der Browser beschränkt.",
+    "description": "Error message when running on about: or addons.mozilla.org."
+  },
 
-    "service_title": {
-        "message": "Kurz-URL-Service",
-        "description": "Options: Label for selecting which service (is.gd, ...) to use."
-    },
-    "service_none": {
-        "message": "(Kein externer Service)",
-        "description": "Options: No shortening service, copy found short URL or full URL only."
-    },
-    "service_custom": {
-        "message": "Benutzerdefiniert (unten angeben)",
-        "description": "Options: Placeholder for custom URL option in dropdown."
-    },
-    "bitly_apikey_title": {
-        "message": "Bitly Generic Access Token",
-        "description": "Options: Label for Bitly API key text field."
-    },
-    "bitly_apikey_description": {
-        "message": "API key mit Bitly anlegen",
-        "description": "Options: Link to generate Bitly API key."
-    },
-    "kuttit_apikey_title": {
-        "message": "Kutt.it API Key",
-        "description": "Options: Label for Kutt.it API key text field."
-    },
-    "kuttit_apikey_description": {
-        "message": "API Key mit Kutt.it anlegen",
-        "description": "Options: Link to generate Kutt.it API key."
-    },
-    "kuttit_domain_title": {
-        "message": "Kutt.it Custom Domain",
-        "description": "Options: Label for Kutt.it custom domain text field."
-    },
-    "kuttit_domain_description": {
-        "message": "(optional) eine eigene Domain mit kutt.it benutzen",
-        "description": "Options: Link to set Kutt.it custom domain."
-    },
-    "tly_apikey_title": {
-        "message": "t.ly API Key",
-        "description": "Options: Label for t.ly API key text field."
-    },
-    "tly_apikey_description": {
-        "message": "API Key mit t.ly anlegen",
-        "description": "Options: Link to generate t.ly API key."
-    },
-    "tly_domain_title": {
-        "message": "t.ly Custom Domain",
-        "description": "Options: Label for t.ly custom domain text field."
-    },
-    "tly_domain_description": {
-        "message": "(optional) eine eigene Domain mit t.ly benutzen",
-        "description": "Options: Link to set t.ly custom domain."
-    },
-    "customurl_title": {
-        "message": "Benutzer-URL",
-        "description": "Options: Label for custom URL text field."
-    },
-    "customurl_description": {
-        "message": "Verwenden Sie %URL% als Platzhalter für die lange URL.",
-        "description": "Options: Help text for custom URL."
-    },
+  "service_title": {
+    "message": "Kurz-URL-Service",
+    "description": "Options: Label for selecting which service (is.gd, ...) to use."
+  },
+  "service_none": {
+    "message": "(Kein externer Service)",
+    "description": "Options: No shortening service, copy found short URL or full URL only."
+  },
+  "service_custom": {
+    "message": "Benutzerdefiniert (unten angeben)",
+    "description": "Options: Placeholder for custom URL option in dropdown."
+  },
+  "bitly_apikey_title": {
+    "message": "Bitly Generic Access Token",
+    "description": "Options: Label for Bitly API key text field."
+  },
+  "bitly_apikey_description": {
+    "message": "API key mit Bitly anlegen",
+    "description": "Options: Link to generate Bitly API key."
+  },
+  "kuttit_apikey_title": {
+    "message": "Kutt.it API Key",
+    "description": "Options: Label for Kutt.it API key text field."
+  },
+  "kuttit_apikey_description": {
+    "message": "API Key mit Kutt.it anlegen",
+    "description": "Options: Link to generate Kutt.it API key."
+  },
+  "kuttit_domain_title": {
+    "message": "Kutt.it Custom Domain",
+    "description": "Options: Label for Kutt.it custom domain text field."
+  },
+  "kuttit_domain_description": {
+    "message": "(optional) eine eigene Domain mit kutt.it benutzen",
+    "description": "Options: Link to set Kutt.it custom domain."
+  },
+  "tly_apikey_title": {
+    "message": "t.ly API Key",
+    "description": "Options: Label for t.ly API key text field."
+  },
+  "tly_apikey_description": {
+    "message": "API Key mit t.ly anlegen",
+    "description": "Options: Link to generate t.ly API key."
+  },
+  "tly_domain_title": {
+    "message": "t.ly Custom Domain",
+    "description": "Options: Label for t.ly custom domain text field."
+  },
+  "tly_domain_description": {
+    "message": "(optional) eine eigene Domain mit t.ly benutzen",
+    "description": "Options: Link to set t.ly custom domain."
+  },
+  "customurl_title": {
+    "message": "Benutzer-URL",
+    "description": "Options: Label for custom URL text field."
+  },
+  "customurl_description": {
+    "message": "Verwenden Sie %URL% als Platzhalter für die lange URL.",
+    "description": "Options: Help text for custom URL."
+  },
 
-    "shorten_canonical_title": {
-        "message": "Kanonische URL kürzen wenn länger als",
-        "description": "Options: Label for maximum URL length before forcing shortening."
-    },
-    "shorten_canonical_description": {
-        "message": "Manche Seiten haben 'kurze' URLs, die nicht wirklich kurz sind. Benutze den Kurz-URL-Service wenn die kanonische URL länger ist als X Zeichen. (0 = niemals kürzen)",
-        "description": "Options: Help text for forcing shortening of long canonical URLs."
-    },
+  "shorten_canonical_title": {
+    "message": "Kanonische URL kürzen wenn länger als",
+    "description": "Options: Label for maximum URL length before forcing shortening."
+  },
+  "shorten_canonical_description": {
+    "message": "Manche Seiten haben 'kurze' URLs, die nicht wirklich kurz sind. Benutze den Kurz-URL-Service wenn die kanonische URL länger ist als X Zeichen. (0 = niemals kürzen)",
+    "description": "Options: Help text for forcing shortening of long canonical URLs."
+  },
 
-    "use_special_title": {
-        "message": "Besondere URL-Formate für bekannte Seiten verwenden",
-        "description": "Options: Label for using youtu.be and other special known short URLs."
-    },
-    "use_special_description": {
-        "message": "Manche Seiten haben spezielle Kurz-URLs, z.B. youtu.be.",
-        "description": "Options: Help text for using special shortening cases."
-    },
+  "use_special_title": {
+    "message": "Besondere URL-Formate für bekannte Seiten verwenden",
+    "description": "Options: Label for using youtu.be and other special known short URLs."
+  },
+  "use_special_description": {
+    "message": "Manche Seiten haben spezielle Kurz-URLs, z.B. youtu.be.",
+    "description": "Options: Help text for using special shortening cases."
+  },
 
-    "strip_utm_title": {
-        "message": "?utm_* Parameter aus der URL entfernen",
-        "description": "Options: Label for removing known marketing parameters from URLs."
-    },
-    "strip_utm_description": {
-        "message": "Marketing-Kampagnen fügen oft unnötige ?utm_campaign=irgendwas Parameter in die URL ein, die wir problemlos entfernen können.",
-        "description": "Options: Help text for removing known marketing parameters from URL."
-    },
+  "strip_utm_title": {
+    "message": "?utm_* Parameter aus der URL entfernen",
+    "description": "Options: Label for removing known marketing parameters from URLs."
+  },
+  "strip_utm_description": {
+    "message": "Marketing-Kampagnen fügen oft unnötige ?utm_campaign=irgendwas Parameter in die URL ein, die wir problemlos entfernen können.",
+    "description": "Options: Help text for removing known marketing parameters from URL."
+  },
 
-    "keep_hash_title": {
-        "message": "URL #hash beibehalten",
-        "description": "Options: Label for keeping URL #hash if present."
-    },
-    "keep_hash_description": {
-        "message": "Fügt #hash Teil von meineseite.de/seite#hash der Kurz-URL wieder hinzu.",
-        "description": "Options: Help text for keeping URL #hash if present."
-    },
+  "keep_hash_title": {
+    "message": "URL #hash beibehalten",
+    "description": "Options: Label for keeping URL #hash if present."
+  },
+  "keep_hash_description": {
+    "message": "Fügt #hash Teil von meineseite.de/seite#hash der Kurz-URL wieder hinzu.",
+    "description": "Options: Help text for keeping URL #hash if present."
+  },
 
-    "notify_title": {
-        "message": "Hinweis-Popup anzeigen wenn erfolgreich",
-        "description": "Options: Label for showing notification popup when URL was generated."
-    },
-    "notify_description": {
-        "message": "Fehler werden immer angezeigt.",
-        "description": "Options: Help text for showing notification popup on success."
-    },
+  "notify_title": {
+    "message": "Hinweis-Popup anzeigen wenn erfolgreich",
+    "description": "Options: Label for showing notification popup when URL was generated."
+  },
+  "notify_description": {
+    "message": "Fehler werden immer angezeigt.",
+    "description": "Options: Help text for showing notification popup on success."
+  },
 
-    "copy_title_title": {
-        "message": "Seiten-Titel zusammen mit Kurz-URL kopieren",
-        "description": "Options: Label for copying page title along with URL."
-    },
-    "copy_title_description": {
-        "message": "Beispiel: 'So why are Pandas so cute? http://nyti.ms/2xGSRyh'",
-        "description": "Options: Help text for copying page title with URL."
-    },
+  "copy_title_title": {
+    "message": "Seiten-Titel zusammen mit Kurz-URL kopieren",
+    "description": "Options: Label for copying page title along with URL."
+  },
+  "copy_title_description": {
+    "message": "Beispiel: 'So why are Pandas so cute? http://nyti.ms/2xGSRyh'",
+    "description": "Options: Help text for copying page title with URL."
+  },
 
-    "save_button": {
-        "message": "Speichern",
-        "description": "Options: Button label for save options."
-    },
-    "saved_notice": {
-        "message": "Gespeichert!",
-        "description": "Options: Indicator that options were saved."
-    }
+  "save_button": {
+    "message": "Speichern",
+    "description": "Options: Button label for save options."
+  },
+  "saved_notice": {
+    "message": "Gespeichert!",
+    "description": "Options: Indicator that options were saved."
+  }
 }

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -1,147 +1,163 @@
 {
-  "extensionDescription": {
-    "message": "Eine Kurz-URL für die aktuelle Seite finden oder erstellen.",
-    "description": ""
-  },
-  "extensionName": {
-    "message": "Copy ShortURL",
-    "description": "name of extension"
-  },
-  "browserAction_label": {
-    "message": "Kurz-URL kopieren",
-    "description": "Toolbar button label text."
-  },
-  "menuitem_label": {
-    "message": "Kurz-URL kopieren",
-    "description": "Context menu item label text for page."
-  },
-  "shorten_link_label": {
-    "message": "Kurz-URL für diesen Link kopieren",
-    "description": "Context menu item label text for link."
-  },
-  "shorten_img_label": {
-    "message": "Kurz-URL für dieses Bild kopieren",
-    "description": "Context menu item label text for image."
-  },
+    "extensionDescription": {
+        "message": "Eine Kurz-URL für die aktuelle Seite finden oder erstellen.",
+        "description": ""
+    },
+    "extensionName": {
+        "message": "Copy ShortURL",
+        "description": "name of extension"
+    },
+    "browserAction_label": {
+        "message": "Kurz-URL kopieren",
+        "description": "Toolbar button label text."
+    },
+    "menuitem_label": {
+        "message": "Kurz-URL kopieren",
+        "description": "Context menu item label text for page."
+    },
+    "shorten_link_label": {
+        "message": "Kurz-URL für diesen Link kopieren",
+        "description": "Context menu item label text for link."
+    },
+    "shorten_img_label": {
+        "message": "Kurz-URL für dieses Bild kopieren",
+        "description": "Context menu item label text for image."
+    },
 
-  "shorten_error": {
-    "message": "Oh-oh, Fehler beim Erstellen der Kurz-URL.",
-    "description": "Error message when shortening URL was unsuccessful."
-  },
-  "apikey_error": {
-    "message": "Kein API key in den Einstellungen.",
-    "description": "Error message when shortening service needs an API key and none was provided."
-  },
-  "error_host_permission": {
-    "message": "Leider funktioniert Copy ShortURL nicht auf Seiten, die der Browser beschränkt.",
-    "description": "Error message when running on about: or addons.mozilla.org."
-  },
+    "shorten_error": {
+        "message": "Oh-oh, Fehler beim Erstellen der Kurz-URL.",
+        "description": "Error message when shortening URL was unsuccessful."
+    },
+    "apikey_error": {
+        "message": "Kein API key in den Einstellungen.",
+        "description": "Error message when shortening service needs an API key and none was provided."
+    },
+    "error_host_permission": {
+        "message": "Leider funktioniert Copy ShortURL nicht auf Seiten, die der Browser beschränkt.",
+        "description": "Error message when running on about: or addons.mozilla.org."
+    },
 
-  "service_title": {
-    "message": "Kurz-URL-Service",
-    "description": "Options: Label for selecting which service (is.gd, ...) to use."
-  },
-  "service_none": {
-    "message": "(Kein externer Service)",
-    "description": "Options: No shortening service, copy found short URL or full URL only."
-  },
-  "service_custom": {
-    "message": "Benutzerdefiniert (unten angeben)",
-    "description": "Options: Placeholder for custom URL option in dropdown."
-  },
-  "bitly_apikey_title": {
-    "message": "Bitly Generic Access Token",
-    "description": "Options: Label for Bitly API key text field."
-  },
-  "bitly_apikey_description": {
-    "message": "API key mit Bitly anlegen",
-    "description": "Options: Link to generate Bitly API key."
-  },
-  "kuttit_apikey_title": {
-    "message": "Kutt.it API Key",
-    "description": "Options: Label for Kutt.it API key text field."
-  },
-  "kuttit_apikey_description": {
-    "message": "API Key mit Kutt.it anlegen",
-    "description": "Options: Link to generate Kutt.it API key."
-  },
-  "kuttit_domain_title": {
-    "message": "Kutt.it Custom Domain",
-    "description": "Options: Label for Kutt.it custom domain text field."
-  },
-  "kuttit_domain_description": {
-    "message": "(optional) eine eigene Domain mit kutt.it benutzen",
-    "description": "Options: Link to set Kutt.it custom domain."
-  },
-  "customurl_title": {
-    "message": "Benutzer-URL",
-    "description": "Options: Label for custom URL text field."
-  },
-  "customurl_description": {
-    "message": "Verwenden Sie %URL% als Platzhalter für die lange URL.",
-    "description": "Options: Help text for custom URL."
-  },
+    "service_title": {
+        "message": "Kurz-URL-Service",
+        "description": "Options: Label for selecting which service (is.gd, ...) to use."
+    },
+    "service_none": {
+        "message": "(Kein externer Service)",
+        "description": "Options: No shortening service, copy found short URL or full URL only."
+    },
+    "service_custom": {
+        "message": "Benutzerdefiniert (unten angeben)",
+        "description": "Options: Placeholder for custom URL option in dropdown."
+    },
+    "bitly_apikey_title": {
+        "message": "Bitly Generic Access Token",
+        "description": "Options: Label for Bitly API key text field."
+    },
+    "bitly_apikey_description": {
+        "message": "API key mit Bitly anlegen",
+        "description": "Options: Link to generate Bitly API key."
+    },
+    "kuttit_apikey_title": {
+        "message": "Kutt.it API Key",
+        "description": "Options: Label for Kutt.it API key text field."
+    },
+    "kuttit_apikey_description": {
+        "message": "API Key mit Kutt.it anlegen",
+        "description": "Options: Link to generate Kutt.it API key."
+    },
+    "kuttit_domain_title": {
+        "message": "Kutt.it Custom Domain",
+        "description": "Options: Label for Kutt.it custom domain text field."
+    },
+    "kuttit_domain_description": {
+        "message": "(optional) eine eigene Domain mit kutt.it benutzen",
+        "description": "Options: Link to set Kutt.it custom domain."
+    },
+    "tly_apikey_title": {
+        "message": "t.ly API Key",
+        "description": "Options: Label for t.ly API key text field."
+    },
+    "tly_apikey_description": {
+        "message": "API Key mit t.ly anlegen",
+        "description": "Options: Link to generate t.ly API key."
+    },
+    "tly_domain_title": {
+        "message": "t.ly Custom Domain",
+        "description": "Options: Label for t.ly custom domain text field."
+    },
+    "tly_domain_description": {
+        "message": "(optional) eine eigene Domain mit t.ly benutzen",
+        "description": "Options: Link to set t.ly custom domain."
+    },
+    "customurl_title": {
+        "message": "Benutzer-URL",
+        "description": "Options: Label for custom URL text field."
+    },
+    "customurl_description": {
+        "message": "Verwenden Sie %URL% als Platzhalter für die lange URL.",
+        "description": "Options: Help text for custom URL."
+    },
 
-  "shorten_canonical_title": {
-    "message": "Kanonische URL kürzen wenn länger als",
-    "description": "Options: Label for maximum URL length before forcing shortening."
-  },
-  "shorten_canonical_description": {
-    "message": "Manche Seiten haben 'kurze' URLs, die nicht wirklich kurz sind. Benutze den Kurz-URL-Service wenn die kanonische URL länger ist als X Zeichen. (0 = niemals kürzen)",
-    "description": "Options: Help text for forcing shortening of long canonical URLs."
-  },
+    "shorten_canonical_title": {
+        "message": "Kanonische URL kürzen wenn länger als",
+        "description": "Options: Label for maximum URL length before forcing shortening."
+    },
+    "shorten_canonical_description": {
+        "message": "Manche Seiten haben 'kurze' URLs, die nicht wirklich kurz sind. Benutze den Kurz-URL-Service wenn die kanonische URL länger ist als X Zeichen. (0 = niemals kürzen)",
+        "description": "Options: Help text for forcing shortening of long canonical URLs."
+    },
 
-  "use_special_title": {
-    "message": "Besondere URL-Formate für bekannte Seiten verwenden",
-    "description": "Options: Label for using youtu.be and other special known short URLs."
-  },
-  "use_special_description": {
-    "message": "Manche Seiten haben spezielle Kurz-URLs, z.B. youtu.be.",
-    "description": "Options: Help text for using special shortening cases."
-  },
+    "use_special_title": {
+        "message": "Besondere URL-Formate für bekannte Seiten verwenden",
+        "description": "Options: Label for using youtu.be and other special known short URLs."
+    },
+    "use_special_description": {
+        "message": "Manche Seiten haben spezielle Kurz-URLs, z.B. youtu.be.",
+        "description": "Options: Help text for using special shortening cases."
+    },
 
-  "strip_utm_title": {
-    "message": "?utm_* Parameter aus der URL entfernen",
-    "description": "Options: Label for removing known marketing parameters from URLs."
-  },
-  "strip_utm_description": {
-    "message": "Marketing-Kampagnen fügen oft unnötige ?utm_campaign=irgendwas Parameter in die URL ein, die wir problemlos entfernen können.",
-    "description": "Options: Help text for removing known marketing parameters from URL."
-  },
+    "strip_utm_title": {
+        "message": "?utm_* Parameter aus der URL entfernen",
+        "description": "Options: Label for removing known marketing parameters from URLs."
+    },
+    "strip_utm_description": {
+        "message": "Marketing-Kampagnen fügen oft unnötige ?utm_campaign=irgendwas Parameter in die URL ein, die wir problemlos entfernen können.",
+        "description": "Options: Help text for removing known marketing parameters from URL."
+    },
 
-  "keep_hash_title": {
-    "message": "URL #hash beibehalten",
-    "description": "Options: Label for keeping URL #hash if present."
-  },
-  "keep_hash_description": {
-    "message": "Fügt #hash Teil von meineseite.de/seite#hash der Kurz-URL wieder hinzu.",
-    "description": "Options: Help text for keeping URL #hash if present."
-  },
+    "keep_hash_title": {
+        "message": "URL #hash beibehalten",
+        "description": "Options: Label for keeping URL #hash if present."
+    },
+    "keep_hash_description": {
+        "message": "Fügt #hash Teil von meineseite.de/seite#hash der Kurz-URL wieder hinzu.",
+        "description": "Options: Help text for keeping URL #hash if present."
+    },
 
- "notify_title": {
-    "message": "Hinweis-Popup anzeigen wenn erfolgreich",
-    "description": "Options: Label for showing notification popup when URL was generated."
-  },
-  "notify_description": {
-    "message": "Fehler werden immer angezeigt.",
-    "description": "Options: Help text for showing notification popup on success."
-  },
+    "notify_title": {
+        "message": "Hinweis-Popup anzeigen wenn erfolgreich",
+        "description": "Options: Label for showing notification popup when URL was generated."
+    },
+    "notify_description": {
+        "message": "Fehler werden immer angezeigt.",
+        "description": "Options: Help text for showing notification popup on success."
+    },
 
- "copy_title_title": {
-    "message": "Seiten-Titel zusammen mit Kurz-URL kopieren",
-    "description": "Options: Label for copying page title along with URL."
-  },
-  "copy_title_description": {
-    "message": "Beispiel: 'So why are Pandas so cute? http://nyti.ms/2xGSRyh'",
-    "description": "Options: Help text for copying page title with URL."
-  },
+    "copy_title_title": {
+        "message": "Seiten-Titel zusammen mit Kurz-URL kopieren",
+        "description": "Options: Label for copying page title along with URL."
+    },
+    "copy_title_description": {
+        "message": "Beispiel: 'So why are Pandas so cute? http://nyti.ms/2xGSRyh'",
+        "description": "Options: Help text for copying page title with URL."
+    },
 
-  "save_button": {
-    "message": "Speichern",
-    "description": "Options: Button label for save options."
-  },
-  "saved_notice": {
-    "message": "Gespeichert!",
-    "description": "Options: Indicator that options were saved."
-  }
+    "save_button": {
+        "message": "Speichern",
+        "description": "Options: Button label for save options."
+    },
+    "saved_notice": {
+        "message": "Gespeichert!",
+        "description": "Options: Indicator that options were saved."
+    }
 }

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -73,6 +73,22 @@
     "message": "(optional) eine eigene Domain mit kutt.it benutzen",
     "description": "Options: Link to set Kutt.it custom domain."
   },
+  "tly_apikey_title": {
+    "message": "t.ly API Key",
+    "description": "Options: Label for t.ly API key text field."
+  },
+  "tly_apikey_description": {
+    "message": "API Key mit t.ly anlegen",
+    "description": "Options: Link to generate t.ly API key."
+  },
+  "tly_domain_title": {
+    "message": "t.ly Custom Domain",
+    "description": "Options: Label for t.ly custom domain text field."
+  },
+  "tly_domain_description": {
+    "message": "(optional) eine eigene Domain mit t.ly benutzen",
+    "description": "Options: Link to set t.ly custom domain."
+  },
   "customurl_title": {
     "message": "Benutzer-URL",
     "description": "Options: Label for custom URL text field."

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1,163 +1,163 @@
 {
-    "extensionDescription": {
-        "message": "Detect or create a short URL for the current page.",
-        "description": ""
-    },
-    "extensionName": {
-        "message": "Copy ShortURL",
-        "description": "name of extension"
-    },
-    "browserAction_label": {
-        "message": "Copy ShortURL",
-        "description": "Toolbar button label text."
-    },
-    "menuitem_label": {
-        "message": "Copy ShortURL",
-        "description": "Context menu item label text for page."
-    },
-    "shorten_link_label": {
-        "message": "Copy ShortURL for this link",
-        "description": "Context menu item label text for link."
-    },
-    "shorten_img_label": {
-        "message": "Copy ShortURL for this image",
-        "description": "Context menu item label text for image."
-    },
+  "extensionDescription": {
+    "message": "Detect or create a short URL for the current page.",
+    "description": ""
+  },
+  "extensionName": {
+    "message": "Copy ShortURL",
+    "description": "name of extension"
+  },
+  "browserAction_label": {
+    "message": "Copy ShortURL",
+    "description": "Toolbar button label text."
+  },
+  "menuitem_label": {
+    "message": "Copy ShortURL",
+    "description": "Context menu item label text for page."
+  },
+  "shorten_link_label": {
+    "message": "Copy ShortURL for this link",
+    "description": "Context menu item label text for link."
+  },
+  "shorten_img_label": {
+    "message": "Copy ShortURL for this image",
+    "description": "Context menu item label text for image."
+  },
 
-    "shorten_error": {
-        "message": "ZOMG, error creating short URL.",
-        "description": "Error message when shortening URL was unsuccessful."
-    },
-    "apikey_error": {
-        "message": "No API key in preferences.",
-        "description": "Error message when shortening service needs an API key and none was provided."
-    },
-    "error_host_permission": {
-        "message": "Sorry, Copy ShortURL cannot run on pages restricted by the browser.",
-        "description": "Error message when running on about: or addons.mozilla.org."
-    },
+  "shorten_error": {
+    "message": "ZOMG, error creating short URL.",
+    "description": "Error message when shortening URL was unsuccessful."
+  },
+  "apikey_error": {
+    "message": "No API key in preferences.",
+    "description": "Error message when shortening service needs an API key and none was provided."
+  },
+  "error_host_permission": {
+    "message": "Sorry, Copy ShortURL cannot run on pages restricted by the browser.",
+    "description": "Error message when running on about: or addons.mozilla.org."
+  },
 
-    "service_title": {
-        "message": "URL Shortening Service",
-        "description": "Options: Label for selecting which service (is.gd, ...) to use."
-    },
-    "service_none": {
-        "message": "(No external service)",
-        "description": "Options: No shortening service, copy found short URL or full URL only."
-    },
-    "service_custom": {
-        "message": "Custom (specify below)",
-        "description": "Options: Placeholder for custom URL option in dropdown."
-    },
-    "bitly_apikey_title": {
-        "message": "Bitly Generic Access Token",
-        "description": "Options: Label for Bitly API key text field."
-    },
-    "bitly_apikey_description": {
-        "message": "Generate an API key with Bitly",
-        "description": "Options: Link to generate Bitly API key."
-    },
-    "kuttit_apikey_title": {
-        "message": "Kutt.it API Key",
-        "description": "Options: Label for Kutt.it API key text field."
-    },
-    "kuttit_apikey_description": {
-        "message": "Generate an API key with Kutt.it",
-        "description": "Options: Link to generate Kutt.it API key."
-    },
-    "kuttit_domain_title": {
-        "message": "Kutt.it Custom Domain",
-        "description": "Options: Label for Kutt.it custom domain text field."
-    },
-    "kuttit_domain_description": {
-        "message": "(optional) use a custom domain with kutt.it",
-        "description": "Options: Link to set Kutt.it custom domain."
-    },
-    "tly_apikey_title": {
-        "message": "t.ly API Key",
-        "description": "Options: Label for t.ly API key text field."
-    },
-    "tly_apikey_description": {
-        "message": "Generate an API key with t.ly",
-        "description": "Options: Link to generate t.ly API key."
-    },
-    "tly_domain_title": {
-        "message": "t.ly Custom Domain",
-        "description": "Options: Label for t.ly custom domain text field."
-    },
-    "tly_domain_description": {
-        "message": "(optional) use a custom domain with t.ly",
-        "description": "Options: Link to set t.ly custom domain."
-    },
-    "customurl_title": {
-        "message": "Custom URL",
-        "description": "Options: Label for custom URL text field."
-    },
-    "customurl_description": {
-        "message": "use %URL% as placeholder for long URL",
-        "description": "Options: Help text for custom URL."
-    },
+  "service_title": {
+    "message": "URL Shortening Service",
+    "description": "Options: Label for selecting which service (is.gd, ...) to use."
+  },
+  "service_none": {
+    "message": "(No external service)",
+    "description": "Options: No shortening service, copy found short URL or full URL only."
+  },
+  "service_custom": {
+    "message": "Custom (specify below)",
+    "description": "Options: Placeholder for custom URL option in dropdown."
+  },
+  "bitly_apikey_title": {
+    "message": "Bitly Generic Access Token",
+    "description": "Options: Label for Bitly API key text field."
+  },
+  "bitly_apikey_description": {
+    "message": "Generate an API key with Bitly",
+    "description": "Options: Link to generate Bitly API key."
+  },
+  "kuttit_apikey_title": {
+    "message": "Kutt.it API Key",
+    "description": "Options: Label for Kutt.it API key text field."
+  },
+  "kuttit_apikey_description": {
+    "message": "Generate an API key with Kutt.it",
+    "description": "Options: Link to generate Kutt.it API key."
+  },
+  "kuttit_domain_title": {
+    "message": "Kutt.it Custom Domain",
+    "description": "Options: Label for Kutt.it custom domain text field."
+  },
+  "kuttit_domain_description": {
+    "message": "(optional) use a custom domain with kutt.it",
+    "description": "Options: Link to set Kutt.it custom domain."
+  },
+  "tly_apikey_title": {
+    "message": "t.ly API Key",
+    "description": "Options: Label for t.ly API key text field."
+  },
+  "tly_apikey_description": {
+    "message": "Generate an API key with t.ly",
+    "description": "Options: Link to generate t.ly API key."
+  },
+  "tly_domain_title": {
+    "message": "t.ly Custom Domain",
+    "description": "Options: Label for t.ly custom domain text field."
+  },
+  "tly_domain_description": {
+    "message": "(optional) use a custom domain with t.ly",
+    "description": "Options: Link to set t.ly custom domain."
+  },
+  "customurl_title": {
+    "message": "Custom URL",
+    "description": "Options: Label for custom URL text field."
+  },
+  "customurl_description": {
+    "message": "use %URL% as placeholder for long URL",
+    "description": "Options: Help text for custom URL."
+  },
 
-    "shorten_canonical_title": {
-        "message": "Shorten canonical URL if longer than",
-        "description": "Options: Label for maximum URL length before forcing shortening."
-    },
-    "shorten_canonical_description": {
-        "message": "Some sites provide canonical \"short URLs\" that aren't short. Use shortening service if they are longer than X characters. (0 = never shorten)",
-        "description": "Options: Help text for forcing shortening of long canonical URLs."
-    },
+  "shorten_canonical_title": {
+    "message": "Shorten canonical URL if longer than",
+    "description": "Options: Label for maximum URL length before forcing shortening."
+  },
+  "shorten_canonical_description": {
+    "message": "Some sites provide canonical \"short URLs\" that aren't short. Use shortening service if they are longer than X characters. (0 = never shorten)",
+    "description": "Options: Help text for forcing shortening of long canonical URLs."
+  },
 
-    "use_special_title": {
-        "message": "Use special case URL formats for known sites",
-        "description": "Options: Label for using youtu.be and other special known short URLs."
-    },
-    "use_special_description": {
-        "message": "Some sites have special shortening formats, like youtu.be.",
-        "description": "Options: Help text for using special shortening cases."
-    },
+  "use_special_title": {
+    "message": "Use special case URL formats for known sites",
+    "description": "Options: Label for using youtu.be and other special known short URLs."
+  },
+  "use_special_description": {
+    "message": "Some sites have special shortening formats, like youtu.be.",
+    "description": "Options: Help text for using special shortening cases."
+  },
 
-    "strip_utm_title": {
-        "message": "Remove ?utm_* parameters from URL",
-        "description": "Options: Label for removing known marketing parameters from URLs."
-    },
-    "strip_utm_description": {
-        "message": "Marketing campaigns often add unnecessary ?utm_campaign=something tokens to the URL that are safe to remove.",
-        "description": "Options: Help text for removing known marketing parameters from URL."
-    },
+  "strip_utm_title": {
+    "message": "Remove ?utm_* parameters from URL",
+    "description": "Options: Label for removing known marketing parameters from URLs."
+  },
+  "strip_utm_description": {
+    "message": "Marketing campaigns often add unnecessary ?utm_campaign=something tokens to the URL that are safe to remove.",
+    "description": "Options: Help text for removing known marketing parameters from URL."
+  },
 
-    "keep_hash_title": {
-        "message": "Keep #hash in final URL",
-        "description": "Options: Label for keeping URL #hash if present."
-    },
-    "keep_hash_description": {
-        "message": "Add #hash part of mysite.com/page#hash back to shortened URL.",
-        "description": "Options: Help text for keeping URL #hash if present."
-    },
+  "keep_hash_title": {
+    "message": "Keep #hash in final URL",
+    "description": "Options: Label for keeping URL #hash if present."
+  },
+  "keep_hash_description": {
+    "message": "Add #hash part of mysite.com/page#hash back to shortened URL.",
+    "description": "Options: Help text for keeping URL #hash if present."
+  },
 
-    "notify_title": {
-        "message": "Show notification popup on success",
-        "description": "Options: Label for showing notification popup when URL was generated."
-    },
-    "notify_description": {
-        "message": "Errors will always show a notification.",
-        "description": "Options: Help text for showing notification popup on success."
-    },
+  "notify_title": {
+    "message": "Show notification popup on success",
+    "description": "Options: Label for showing notification popup when URL was generated."
+  },
+  "notify_description": {
+    "message": "Errors will always show a notification.",
+    "description": "Options: Help text for showing notification popup on success."
+  },
 
-    "copy_title_title": {
-        "message": "Copy page title in addition to URL",
-        "description": "Options: Label for copying page title along with URL."
-    },
-    "copy_title_description": {
-        "message": "Example: 'So why are Pandas so cute? http://nyti.ms/2xGSRyh'",
-        "description": "Options: Help text for copying page title with URL."
-    },
+  "copy_title_title": {
+    "message": "Copy page title in addition to URL",
+    "description": "Options: Label for copying page title along with URL."
+  },
+  "copy_title_description": {
+    "message": "Example: 'So why are Pandas so cute? http://nyti.ms/2xGSRyh'",
+    "description": "Options: Help text for copying page title with URL."
+  },
 
-    "save_button": {
-        "message": "Save",
-        "description": "Options: Button label for save options."
-    },
-    "saved_notice": {
-        "message": "Saved!",
-        "description": "Options: Indicator that options were saved."
-    }
+  "save_button": {
+    "message": "Save",
+    "description": "Options: Button label for save options."
+  },
+  "saved_notice": {
+    "message": "Saved!",
+    "description": "Options: Indicator that options were saved."
+  }
 }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -73,6 +73,22 @@
     "message": "(optional) use a custom domain with kutt.it",
     "description": "Options: Link to set Kutt.it custom domain."
   },
+  "tly_apikey_title": {
+    "message": "t.ly API Key",
+    "description": "Options: Label for t.ly API key text field."
+  },
+  "tly_apikey_description": {
+    "message": "Generate an API key with t.ly",
+    "description": "Options: Link to generate t.ly API key."
+  },
+  "tly_domain_title": {
+    "message": "t.ly Custom Domain",
+    "description": "Options: Label for t.ly custom domain text field."
+  },
+  "tly_domain_description": {
+    "message": "(optional) use a custom domain with t.ly",
+    "description": "Options: Link to set t.ly custom domain."
+  },
   "customurl_title": {
     "message": "Custom URL",
     "description": "Options: Label for custom URL text field."

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1,147 +1,163 @@
 {
-  "extensionDescription": {
-    "message": "Detect or create a short URL for the current page.",
-    "description": ""
-  },
-  "extensionName": {
-    "message": "Copy ShortURL",
-    "description": "name of extension"
-  },
-  "browserAction_label": {
-    "message": "Copy ShortURL",
-    "description": "Toolbar button label text."
-  },
-  "menuitem_label": {
-    "message": "Copy ShortURL",
-    "description": "Context menu item label text for page."
-  },
-  "shorten_link_label": {
-    "message": "Copy ShortURL for this link",
-    "description": "Context menu item label text for link."
-  },
-  "shorten_img_label": {
-    "message": "Copy ShortURL for this image",
-    "description": "Context menu item label text for image."
-  },
+    "extensionDescription": {
+        "message": "Detect or create a short URL for the current page.",
+        "description": ""
+    },
+    "extensionName": {
+        "message": "Copy ShortURL",
+        "description": "name of extension"
+    },
+    "browserAction_label": {
+        "message": "Copy ShortURL",
+        "description": "Toolbar button label text."
+    },
+    "menuitem_label": {
+        "message": "Copy ShortURL",
+        "description": "Context menu item label text for page."
+    },
+    "shorten_link_label": {
+        "message": "Copy ShortURL for this link",
+        "description": "Context menu item label text for link."
+    },
+    "shorten_img_label": {
+        "message": "Copy ShortURL for this image",
+        "description": "Context menu item label text for image."
+    },
 
-  "shorten_error": {
-    "message": "ZOMG, error creating short URL.",
-    "description": "Error message when shortening URL was unsuccessful."
-  },
-  "apikey_error": {
-    "message": "No API key in preferences.",
-    "description": "Error message when shortening service needs an API key and none was provided."
-  },
-  "error_host_permission": {
-    "message": "Sorry, Copy ShortURL cannot run on pages restricted by the browser.",
-    "description": "Error message when running on about: or addons.mozilla.org."
-  },
+    "shorten_error": {
+        "message": "ZOMG, error creating short URL.",
+        "description": "Error message when shortening URL was unsuccessful."
+    },
+    "apikey_error": {
+        "message": "No API key in preferences.",
+        "description": "Error message when shortening service needs an API key and none was provided."
+    },
+    "error_host_permission": {
+        "message": "Sorry, Copy ShortURL cannot run on pages restricted by the browser.",
+        "description": "Error message when running on about: or addons.mozilla.org."
+    },
 
-  "service_title": {
-    "message": "URL Shortening Service",
-    "description": "Options: Label for selecting which service (is.gd, ...) to use."
-  },
-  "service_none": {
-    "message": "(No external service)",
-    "description": "Options: No shortening service, copy found short URL or full URL only."
-  },
-  "service_custom": {
-    "message": "Custom (specify below)",
-    "description": "Options: Placeholder for custom URL option in dropdown."
-  },
-  "bitly_apikey_title": {
-    "message": "Bitly Generic Access Token",
-    "description": "Options: Label for Bitly API key text field."
-  },
-  "bitly_apikey_description": {
-    "message": "Generate an API key with Bitly",
-    "description": "Options: Link to generate Bitly API key."
-  },
-  "kuttit_apikey_title": {
-    "message": "Kutt.it API Key",
-    "description": "Options: Label for Kutt.it API key text field."
-  },
-  "kuttit_apikey_description": {
-    "message": "Generate an API key with Kutt.it",
-    "description": "Options: Link to generate Kutt.it API key."
-  },
-  "kuttit_domain_title": {
-    "message": "Kutt.it Custom Domain",
-    "description": "Options: Label for Kutt.it custom domain text field."
-  },
-  "kuttit_domain_description": {
-    "message": "(optional) use a custom domain with kutt.it",
-    "description": "Options: Link to set Kutt.it custom domain."
-  },
-  "customurl_title": {
-    "message": "Custom URL",
-    "description": "Options: Label for custom URL text field."
-  },
-  "customurl_description": {
-    "message": "use %URL% as placeholder for long URL",
-    "description": "Options: Help text for custom URL."
-  },
+    "service_title": {
+        "message": "URL Shortening Service",
+        "description": "Options: Label for selecting which service (is.gd, ...) to use."
+    },
+    "service_none": {
+        "message": "(No external service)",
+        "description": "Options: No shortening service, copy found short URL or full URL only."
+    },
+    "service_custom": {
+        "message": "Custom (specify below)",
+        "description": "Options: Placeholder for custom URL option in dropdown."
+    },
+    "bitly_apikey_title": {
+        "message": "Bitly Generic Access Token",
+        "description": "Options: Label for Bitly API key text field."
+    },
+    "bitly_apikey_description": {
+        "message": "Generate an API key with Bitly",
+        "description": "Options: Link to generate Bitly API key."
+    },
+    "kuttit_apikey_title": {
+        "message": "Kutt.it API Key",
+        "description": "Options: Label for Kutt.it API key text field."
+    },
+    "kuttit_apikey_description": {
+        "message": "Generate an API key with Kutt.it",
+        "description": "Options: Link to generate Kutt.it API key."
+    },
+    "kuttit_domain_title": {
+        "message": "Kutt.it Custom Domain",
+        "description": "Options: Label for Kutt.it custom domain text field."
+    },
+    "kuttit_domain_description": {
+        "message": "(optional) use a custom domain with kutt.it",
+        "description": "Options: Link to set Kutt.it custom domain."
+    },
+    "tly_apikey_title": {
+        "message": "t.ly API Key",
+        "description": "Options: Label for t.ly API key text field."
+    },
+    "tly_apikey_description": {
+        "message": "Generate an API key with t.ly",
+        "description": "Options: Link to generate t.ly API key."
+    },
+    "tly_domain_title": {
+        "message": "t.ly Custom Domain",
+        "description": "Options: Label for t.ly custom domain text field."
+    },
+    "tly_domain_description": {
+        "message": "(optional) use a custom domain with t.ly",
+        "description": "Options: Link to set t.ly custom domain."
+    },
+    "customurl_title": {
+        "message": "Custom URL",
+        "description": "Options: Label for custom URL text field."
+    },
+    "customurl_description": {
+        "message": "use %URL% as placeholder for long URL",
+        "description": "Options: Help text for custom URL."
+    },
 
-  "shorten_canonical_title": {
-    "message": "Shorten canonical URL if longer than",
-    "description": "Options: Label for maximum URL length before forcing shortening."
-  },
-  "shorten_canonical_description": {
-    "message": "Some sites provide canonical \"short URLs\" that aren't short. Use shortening service if they are longer than X characters. (0 = never shorten)",
-    "description": "Options: Help text for forcing shortening of long canonical URLs."
-  },
+    "shorten_canonical_title": {
+        "message": "Shorten canonical URL if longer than",
+        "description": "Options: Label for maximum URL length before forcing shortening."
+    },
+    "shorten_canonical_description": {
+        "message": "Some sites provide canonical \"short URLs\" that aren't short. Use shortening service if they are longer than X characters. (0 = never shorten)",
+        "description": "Options: Help text for forcing shortening of long canonical URLs."
+    },
 
-  "use_special_title": {
-    "message": "Use special case URL formats for known sites",
-    "description": "Options: Label for using youtu.be and other special known short URLs."
-  },
-  "use_special_description": {
-    "message": "Some sites have special shortening formats, like youtu.be.",
-    "description": "Options: Help text for using special shortening cases."
-  },
+    "use_special_title": {
+        "message": "Use special case URL formats for known sites",
+        "description": "Options: Label for using youtu.be and other special known short URLs."
+    },
+    "use_special_description": {
+        "message": "Some sites have special shortening formats, like youtu.be.",
+        "description": "Options: Help text for using special shortening cases."
+    },
 
-  "strip_utm_title": {
-    "message": "Remove ?utm_* parameters from URL",
-    "description": "Options: Label for removing known marketing parameters from URLs."
-  },
-  "strip_utm_description": {
-    "message": "Marketing campaigns often add unnecessary ?utm_campaign=something tokens to the URL that are safe to remove.",
-    "description": "Options: Help text for removing known marketing parameters from URL."
-  },
+    "strip_utm_title": {
+        "message": "Remove ?utm_* parameters from URL",
+        "description": "Options: Label for removing known marketing parameters from URLs."
+    },
+    "strip_utm_description": {
+        "message": "Marketing campaigns often add unnecessary ?utm_campaign=something tokens to the URL that are safe to remove.",
+        "description": "Options: Help text for removing known marketing parameters from URL."
+    },
 
-  "keep_hash_title": {
-    "message": "Keep #hash in final URL",
-    "description": "Options: Label for keeping URL #hash if present."
-  },
-  "keep_hash_description": {
-    "message": "Add #hash part of mysite.com/page#hash back to shortened URL.",
-    "description": "Options: Help text for keeping URL #hash if present."
-  },
+    "keep_hash_title": {
+        "message": "Keep #hash in final URL",
+        "description": "Options: Label for keeping URL #hash if present."
+    },
+    "keep_hash_description": {
+        "message": "Add #hash part of mysite.com/page#hash back to shortened URL.",
+        "description": "Options: Help text for keeping URL #hash if present."
+    },
 
- "notify_title": {
-    "message": "Show notification popup on success",
-    "description": "Options: Label for showing notification popup when URL was generated."
-  },
-  "notify_description": {
-    "message": "Errors will always show a notification.",
-    "description": "Options: Help text for showing notification popup on success."
-  },
+    "notify_title": {
+        "message": "Show notification popup on success",
+        "description": "Options: Label for showing notification popup when URL was generated."
+    },
+    "notify_description": {
+        "message": "Errors will always show a notification.",
+        "description": "Options: Help text for showing notification popup on success."
+    },
 
- "copy_title_title": {
-    "message": "Copy page title in addition to URL",
-    "description": "Options: Label for copying page title along with URL."
-  },
-  "copy_title_description": {
-    "message": "Example: 'So why are Pandas so cute? http://nyti.ms/2xGSRyh'",
-    "description": "Options: Help text for copying page title with URL."
-  },
+    "copy_title_title": {
+        "message": "Copy page title in addition to URL",
+        "description": "Options: Label for copying page title along with URL."
+    },
+    "copy_title_description": {
+        "message": "Example: 'So why are Pandas so cute? http://nyti.ms/2xGSRyh'",
+        "description": "Options: Help text for copying page title with URL."
+    },
 
-  "save_button": {
-    "message": "Save",
-    "description": "Options: Button label for save options."
-  },
-  "saved_notice": {
-    "message": "Saved!",
-    "description": "Options: Indicator that options were saved."
-  }
+    "save_button": {
+        "message": "Save",
+        "description": "Options: Button label for save options."
+    },
+    "saved_notice": {
+        "message": "Saved!",
+        "description": "Options: Indicator that options were saved."
+    }
 }

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -58,20 +58,36 @@
     "description": "Options: Link to generate Bitly API key."
   },
   "kuttit_apikey_title": {
-    "message": "Kutt.it API Key",
+    "message": "Kutt.it API 键值",
     "description": "Options: Label for Kutt.it API key text field."
   },
   "kuttit_apikey_description": {
-    "message": "Generate an API key with Kutt.it",
+    "message": "建立 Kutt.it 的 API 键值",
     "description": "Options: Link to generate Kutt.it API key."
   },
   "kuttit_domain_title": {
-    "message": "Kutt.it Custom Domain",
+    "message": "Kutt.it 自定义网域",
     "description": "Options: Label for Kutt.it custom domain text field."
   },
   "kuttit_domain_description": {
-    "message": "(optional) use a custom domain with kutt.it",
+    "message": "(选用) 使用 Kutt.it 的自定义网域",
     "description": "Options: Link to set Kutt.it custom domain."
+  },
+  "tly_apikey_title": {
+    "message": "t.ly API 键值",
+    "description": "Options: Label for t.ly API key text field."
+  },
+  "tly_apikey_description": {
+    "message": "建立 t.ly 的 API 键值",
+    "description": "Options: Link to generate t.ly API key."
+  },
+  "tly_domain_title": {
+    "message": "t.ly 自定义网域",
+    "description": "Options: Label for t.ly custom domain text field."
+  },
+  "tly_domain_description": {
+    "message": "(选用) 使用 t.ly 的自定义网域",
+    "description": "Options: Link to set t.ly custom domain."
   },
   "customurl_title": {
     "message": "自定义网址",

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -1,163 +1,163 @@
 {
-    "extensionDescription": {
-        "message": "检测或创建当前页面的短网址。",
-        "description": ""
-    },
-    "extensionName": {
-        "message": "Copy ShortURL",
-        "description": "name of extension"
-    },
-    "browserAction_label": {
-        "message": "复制短网址",
-        "description": "Toolbar button label text."
-    },
-    "menuitem_label": {
-        "message": "复制短网址",
-        "description": "Context menu item label text for page."
-    },
-    "shorten_link_label": {
-        "message": "为此链接复制短网址",
-        "description": "Context menu item label text for link."
-    },
-    "shorten_img_label": {
-        "message": "Copy ShortURL for this image",
-        "description": "Context menu item label text for image."
-    },
+  "extensionDescription": {
+    "message": "检测或创建当前页面的短网址。",
+    "description": ""
+  },
+  "extensionName": {
+    "message": "Copy ShortURL",
+    "description": "name of extension"
+  },
+  "browserAction_label": {
+    "message": "复制短网址",
+    "description": "Toolbar button label text."
+  },
+  "menuitem_label": {
+    "message": "复制短网址",
+    "description": "Context menu item label text for page."
+  },
+  "shorten_link_label": {
+    "message": "为此链接复制短网址",
+    "description": "Context menu item label text for link."
+  },
+  "shorten_img_label": {
+    "message": "Copy ShortURL for this image",
+    "description": "Context menu item label text for image."
+  },
 
-    "shorten_error": {
-        "message": "很抱歉，创建短网址出错。",
-        "description": "Error message when shortening URL was unsuccessful."
-    },
-    "apikey_error": {
-        "message": "没有在选项中配置 API 键值。",
-        "description": "Error message when shortening service needs an API key and none was provided."
-    },
-    "error_host_permission": {
-        "message": "抱歉，Copy ShortURL 因浏览器限制不能在此页面上运行。",
-        "description": "Error message when running on about: or addons.mozilla.org."
-    },
+  "shorten_error": {
+    "message": "很抱歉，创建短网址出错。",
+    "description": "Error message when shortening URL was unsuccessful."
+  },
+  "apikey_error": {
+    "message": "没有在选项中配置 API 键值。",
+    "description": "Error message when shortening service needs an API key and none was provided."
+  },
+  "error_host_permission": {
+    "message": "抱歉，Copy ShortURL 因浏览器限制不能在此页面上运行。",
+    "description": "Error message when running on about: or addons.mozilla.org."
+  },
 
-    "service_title": {
-        "message": "网址缩短服务",
-        "description": "Options: Label for selecting which service (is.gd, ...) to use."
-    },
-    "service_none": {
-        "message": "(No external service)",
-        "description": "Options: No shortening service, copy found short URL or full URL only."
-    },
-    "service_custom": {
-        "message": "自定义 (下方指定)",
-        "description": "Options: Placeholder for custom URL option in dropdown."
-    },
-    "bitly_apikey_title": {
-        "message": "Bitly API 键值",
-        "description": "Options: Label for Bitly API key text field."
-    },
-    "bitly_apikey_description": {
-        "message": "在 Bitly 上生成 API 键值",
-        "description": "Options: Link to generate Bitly API key."
-    },
-    "kuttit_apikey_title": {
-        "message": "Kutt.it API 键值",
-        "description": "Options: Label for Kutt.it API key text field."
-    },
-    "kuttit_apikey_description": {
-        "message": "建立 Kutt.it 的 API 键值",
-        "description": "Options: Link to generate Kutt.it API key."
-    },
-    "kuttit_domain_title": {
-        "message": "Kutt.it 自定义网域",
-        "description": "Options: Label for Kutt.it custom domain text field."
-    },
-    "kuttit_domain_description": {
-        "message": "(选用) 使用 Kutt.it 的自定义网域",
-        "description": "Options: Link to set Kutt.it custom domain."
-    },
-    "tly_apikey_title": {
-        "message": "t.ly API 键值",
-        "description": "Options: Label for t.ly API key text field."
-    },
-    "tly_apikey_description": {
-        "message": "建立 t.ly 的 API 键值",
-        "description": "Options: Link to generate t.ly API key."
-    },
-    "tly_domain_title": {
-        "message": "t.ly 自定义网域",
-        "description": "Options: Label for t.ly custom domain text field."
-    },
-    "tly_domain_description": {
-        "message": "(选用) 使用 t.ly 的自定义网域",
-        "description": "Options: Link to set t.ly custom domain."
-    },
-    "customurl_title": {
-        "message": "自定义网址",
-        "description": "Options: Label for custom URL text field."
-    },
-    "customurl_description": {
-        "message": "使用 %URL% 作为长（原始）网址的占位符",
-        "description": "Options: Help text for custom URL."
-    },
+  "service_title": {
+    "message": "网址缩短服务",
+    "description": "Options: Label for selecting which service (is.gd, ...) to use."
+  },
+  "service_none": {
+    "message": "(No external service)",
+    "description": "Options: No shortening service, copy found short URL or full URL only."
+  },
+  "service_custom": {
+    "message": "自定义 (下方指定)",
+    "description": "Options: Placeholder for custom URL option in dropdown."
+  },
+  "bitly_apikey_title": {
+    "message": "Bitly API 键值",
+    "description": "Options: Label for Bitly API key text field."
+  },
+  "bitly_apikey_description": {
+    "message": "在 Bitly 上生成 API 键值",
+    "description": "Options: Link to generate Bitly API key."
+  },
+  "kuttit_apikey_title": {
+    "message": "Kutt.it API 键值",
+    "description": "Options: Label for Kutt.it API key text field."
+  },
+  "kuttit_apikey_description": {
+    "message": "建立 Kutt.it 的 API 键值",
+    "description": "Options: Link to generate Kutt.it API key."
+  },
+  "kuttit_domain_title": {
+    "message": "Kutt.it 自定义网域",
+    "description": "Options: Label for Kutt.it custom domain text field."
+  },
+  "kuttit_domain_description": {
+    "message": "(选用) 使用 Kutt.it 的自定义网域",
+    "description": "Options: Link to set Kutt.it custom domain."
+  },
+  "tly_apikey_title": {
+    "message": "t.ly API 键值",
+    "description": "Options: Label for t.ly API key text field."
+  },
+  "tly_apikey_description": {
+    "message": "建立 t.ly 的 API 键值",
+    "description": "Options: Link to generate t.ly API key."
+  },
+  "tly_domain_title": {
+    "message": "t.ly 自定义网域",
+    "description": "Options: Label for t.ly custom domain text field."
+  },
+  "tly_domain_description": {
+    "message": "(选用) 使用 t.ly 的自定义网域",
+    "description": "Options: Link to set t.ly custom domain."
+  },
+  "customurl_title": {
+    "message": "自定义网址",
+    "description": "Options: Label for custom URL text field."
+  },
+  "customurl_description": {
+    "message": "使用 %URL% 作为长（原始）网址的占位符",
+    "description": "Options: Help text for custom URL."
+  },
 
-    "shorten_canonical_title": {
-        "message": "缩短规范的网址，如果字符数超过",
-        "description": "Options: Label for maximum URL length before forcing shortening."
-    },
-    "shorten_canonical_description": {
-        "message": "部分网站本身提供不太短的规范短网址。此处指定长度超过 X 个字符时才使用缩短服务 (0 = 此情况不缩短)",
-        "description": "Options: Help text for forcing shortening of long canonical URLs."
-    },
+  "shorten_canonical_title": {
+    "message": "缩短规范的网址，如果字符数超过",
+    "description": "Options: Label for maximum URL length before forcing shortening."
+  },
+  "shorten_canonical_description": {
+    "message": "部分网站本身提供不太短的规范短网址。此处指定长度超过 X 个字符时才使用缩短服务 (0 = 此情况不缩短)",
+    "description": "Options: Help text for forcing shortening of long canonical URLs."
+  },
 
-    "use_special_title": {
-        "message": "Use special case URL formats for known sites",
-        "description": "Options: Label for using youtu.be and other special known short URLs."
-    },
-    "use_special_description": {
-        "message": "Some sites have special shortening formats, like youtu.be.",
-        "description": "Options: Help text for using special shortening cases."
-    },
+  "use_special_title": {
+    "message": "Use special case URL formats for known sites",
+    "description": "Options: Label for using youtu.be and other special known short URLs."
+  },
+  "use_special_description": {
+    "message": "Some sites have special shortening formats, like youtu.be.",
+    "description": "Options: Help text for using special shortening cases."
+  },
 
-    "strip_utm_title": {
-        "message": "移除网址中的 ?utm_* 参数",
-        "description": "Options: Label for removing known marketing parameters from URLs."
-    },
-    "strip_utm_description": {
-        "message": "营销活动经常添加非必要的 ?utm_campaign=something 参数到网址，它可以安全移除。",
-        "description": "Options: Help text for removing known marketing parameters from URL."
-    },
+  "strip_utm_title": {
+    "message": "移除网址中的 ?utm_* 参数",
+    "description": "Options: Label for removing known marketing parameters from URLs."
+  },
+  "strip_utm_description": {
+    "message": "营销活动经常添加非必要的 ?utm_campaign=something 参数到网址，它可以安全移除。",
+    "description": "Options: Help text for removing known marketing parameters from URL."
+  },
 
-    "keep_hash_title": {
-        "message": "Keep #hash in final URL",
-        "description": "Options: Label for keeping URL #hash if present."
-    },
-    "keep_hash_description": {
-        "message": "Add #hash part of mysite.com/page#hash back to shortened URL.",
-        "description": "Options: Help text for keeping URL #hash if present."
-    },
+  "keep_hash_title": {
+    "message": "Keep #hash in final URL",
+    "description": "Options: Label for keeping URL #hash if present."
+  },
+  "keep_hash_description": {
+    "message": "Add #hash part of mysite.com/page#hash back to shortened URL.",
+    "description": "Options: Help text for keeping URL #hash if present."
+  },
 
-    "notify_title": {
-        "message": "成功时显示通知",
-        "description": "Options: Label for showing notification popup when URL was generated."
-    },
-    "notify_description": {
-        "message": "发生错误始终会显示通知。",
-        "description": "Options: Help text for showing notification popup on success."
-    },
+  "notify_title": {
+    "message": "成功时显示通知",
+    "description": "Options: Label for showing notification popup when URL was generated."
+  },
+  "notify_description": {
+    "message": "发生错误始终会显示通知。",
+    "description": "Options: Help text for showing notification popup on success."
+  },
 
-    "copy_title_title": {
-        "message": "Copy page title in addition to URL",
-        "description": "Options: Label for copying page title along with URL."
-    },
-    "copy_title_description": {
-        "message": "Example: 'So why are Pandas so cute? http://nyti.ms/2xGSRyh'",
-        "description": "Options: Help text for copying page title with URL."
-    },
+  "copy_title_title": {
+    "message": "Copy page title in addition to URL",
+    "description": "Options: Label for copying page title along with URL."
+  },
+  "copy_title_description": {
+    "message": "Example: 'So why are Pandas so cute? http://nyti.ms/2xGSRyh'",
+    "description": "Options: Help text for copying page title with URL."
+  },
 
-    "save_button": {
-        "message": "保存",
-        "description": "Options: Button label for save options."
-    },
-    "saved_notice": {
-        "message": "Saved!",
-        "description": "Options: Indicator that options were saved."
-    }
+  "save_button": {
+    "message": "保存",
+    "description": "Options: Button label for save options."
+  },
+  "saved_notice": {
+    "message": "Saved!",
+    "description": "Options: Indicator that options were saved."
+  }
 }

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -1,147 +1,163 @@
 {
-  "extensionDescription": {
-    "message": "检测或创建当前页面的短网址。",
-    "description": ""
-  },
-  "extensionName": {
-    "message": "Copy ShortURL",
-    "description": "name of extension"
-  },
-  "browserAction_label": {
-    "message": "复制短网址",
-    "description": "Toolbar button label text."
-  },
-  "menuitem_label": {
-    "message": "复制短网址",
-    "description": "Context menu item label text for page."
-  },
-  "shorten_link_label": {
-    "message": "为此链接复制短网址",
-    "description": "Context menu item label text for link."
-  },
-  "shorten_img_label": {
-    "message": "Copy ShortURL for this image",
-    "description": "Context menu item label text for image."
-  },
+    "extensionDescription": {
+        "message": "检测或创建当前页面的短网址。",
+        "description": ""
+    },
+    "extensionName": {
+        "message": "Copy ShortURL",
+        "description": "name of extension"
+    },
+    "browserAction_label": {
+        "message": "复制短网址",
+        "description": "Toolbar button label text."
+    },
+    "menuitem_label": {
+        "message": "复制短网址",
+        "description": "Context menu item label text for page."
+    },
+    "shorten_link_label": {
+        "message": "为此链接复制短网址",
+        "description": "Context menu item label text for link."
+    },
+    "shorten_img_label": {
+        "message": "Copy ShortURL for this image",
+        "description": "Context menu item label text for image."
+    },
 
-  "shorten_error": {
-    "message": "很抱歉，创建短网址出错。",
-    "description": "Error message when shortening URL was unsuccessful."
-  },
-  "apikey_error": {
-    "message": "没有在选项中配置 API 键值。",
-    "description": "Error message when shortening service needs an API key and none was provided."
-  },
-  "error_host_permission": {
-    "message": "抱歉，Copy ShortURL 因浏览器限制不能在此页面上运行。",
-    "description": "Error message when running on about: or addons.mozilla.org."
-  },
+    "shorten_error": {
+        "message": "很抱歉，创建短网址出错。",
+        "description": "Error message when shortening URL was unsuccessful."
+    },
+    "apikey_error": {
+        "message": "没有在选项中配置 API 键值。",
+        "description": "Error message when shortening service needs an API key and none was provided."
+    },
+    "error_host_permission": {
+        "message": "抱歉，Copy ShortURL 因浏览器限制不能在此页面上运行。",
+        "description": "Error message when running on about: or addons.mozilla.org."
+    },
 
-  "service_title": {
-    "message": "网址缩短服务",
-    "description": "Options: Label for selecting which service (is.gd, ...) to use."
-  },
-  "service_none": {
-    "message": "(No external service)",
-    "description": "Options: No shortening service, copy found short URL or full URL only."
-  },
-  "service_custom": {
-    "message": "自定义 (下方指定)",
-    "description": "Options: Placeholder for custom URL option in dropdown."
-  },
-  "bitly_apikey_title": {
-    "message": "Bitly API 键值",
-    "description": "Options: Label for Bitly API key text field."
-  },
-  "bitly_apikey_description": {
-    "message": "在 Bitly 上生成 API 键值",
-    "description": "Options: Link to generate Bitly API key."
-  },
-  "kuttit_apikey_title": {
-    "message": "Kutt.it API Key",
-    "description": "Options: Label for Kutt.it API key text field."
-  },
-  "kuttit_apikey_description": {
-    "message": "Generate an API key with Kutt.it",
-    "description": "Options: Link to generate Kutt.it API key."
-  },
-  "kuttit_domain_title": {
-    "message": "Kutt.it Custom Domain",
-    "description": "Options: Label for Kutt.it custom domain text field."
-  },
-  "kuttit_domain_description": {
-    "message": "(optional) use a custom domain with kutt.it",
-    "description": "Options: Link to set Kutt.it custom domain."
-  },
-  "customurl_title": {
-    "message": "自定义网址",
-    "description": "Options: Label for custom URL text field."
-  },
-  "customurl_description": {
-    "message": "使用 %URL% 作为长（原始）网址的占位符",
-    "description": "Options: Help text for custom URL."
-  },
+    "service_title": {
+        "message": "网址缩短服务",
+        "description": "Options: Label for selecting which service (is.gd, ...) to use."
+    },
+    "service_none": {
+        "message": "(No external service)",
+        "description": "Options: No shortening service, copy found short URL or full URL only."
+    },
+    "service_custom": {
+        "message": "自定义 (下方指定)",
+        "description": "Options: Placeholder for custom URL option in dropdown."
+    },
+    "bitly_apikey_title": {
+        "message": "Bitly API 键值",
+        "description": "Options: Label for Bitly API key text field."
+    },
+    "bitly_apikey_description": {
+        "message": "在 Bitly 上生成 API 键值",
+        "description": "Options: Link to generate Bitly API key."
+    },
+    "kuttit_apikey_title": {
+        "message": "Kutt.it API 键值",
+        "description": "Options: Label for Kutt.it API key text field."
+    },
+    "kuttit_apikey_description": {
+        "message": "建立 Kutt.it 的 API 键值",
+        "description": "Options: Link to generate Kutt.it API key."
+    },
+    "kuttit_domain_title": {
+        "message": "Kutt.it 自定义网域",
+        "description": "Options: Label for Kutt.it custom domain text field."
+    },
+    "kuttit_domain_description": {
+        "message": "(选用) 使用 Kutt.it 的自定义网域",
+        "description": "Options: Link to set Kutt.it custom domain."
+    },
+    "tly_apikey_title": {
+        "message": "t.ly API 键值",
+        "description": "Options: Label for t.ly API key text field."
+    },
+    "tly_apikey_description": {
+        "message": "建立 t.ly 的 API 键值",
+        "description": "Options: Link to generate t.ly API key."
+    },
+    "tly_domain_title": {
+        "message": "t.ly 自定义网域",
+        "description": "Options: Label for t.ly custom domain text field."
+    },
+    "tly_domain_description": {
+        "message": "(选用) 使用 t.ly 的自定义网域",
+        "description": "Options: Link to set t.ly custom domain."
+    },
+    "customurl_title": {
+        "message": "自定义网址",
+        "description": "Options: Label for custom URL text field."
+    },
+    "customurl_description": {
+        "message": "使用 %URL% 作为长（原始）网址的占位符",
+        "description": "Options: Help text for custom URL."
+    },
 
-  "shorten_canonical_title": {
-    "message": "缩短规范的网址，如果字符数超过",
-    "description": "Options: Label for maximum URL length before forcing shortening."
-  },
-  "shorten_canonical_description": {
-    "message": "部分网站本身提供不太短的规范短网址。此处指定长度超过 X 个字符时才使用缩短服务 (0 = 此情况不缩短)",
-    "description": "Options: Help text for forcing shortening of long canonical URLs."
-  },
+    "shorten_canonical_title": {
+        "message": "缩短规范的网址，如果字符数超过",
+        "description": "Options: Label for maximum URL length before forcing shortening."
+    },
+    "shorten_canonical_description": {
+        "message": "部分网站本身提供不太短的规范短网址。此处指定长度超过 X 个字符时才使用缩短服务 (0 = 此情况不缩短)",
+        "description": "Options: Help text for forcing shortening of long canonical URLs."
+    },
 
-  "use_special_title": {
-    "message": "Use special case URL formats for known sites",
-    "description": "Options: Label for using youtu.be and other special known short URLs."
-  },
-  "use_special_description": {
-    "message": "Some sites have special shortening formats, like youtu.be.",
-    "description": "Options: Help text for using special shortening cases."
-  },
+    "use_special_title": {
+        "message": "Use special case URL formats for known sites",
+        "description": "Options: Label for using youtu.be and other special known short URLs."
+    },
+    "use_special_description": {
+        "message": "Some sites have special shortening formats, like youtu.be.",
+        "description": "Options: Help text for using special shortening cases."
+    },
 
-  "strip_utm_title": {
-    "message": "移除网址中的 ?utm_* 参数",
-    "description": "Options: Label for removing known marketing parameters from URLs."
-  },
-  "strip_utm_description": {
-    "message": "营销活动经常添加非必要的 ?utm_campaign=something 参数到网址，它可以安全移除。",
-    "description": "Options: Help text for removing known marketing parameters from URL."
-  },
+    "strip_utm_title": {
+        "message": "移除网址中的 ?utm_* 参数",
+        "description": "Options: Label for removing known marketing parameters from URLs."
+    },
+    "strip_utm_description": {
+        "message": "营销活动经常添加非必要的 ?utm_campaign=something 参数到网址，它可以安全移除。",
+        "description": "Options: Help text for removing known marketing parameters from URL."
+    },
 
-  "keep_hash_title": {
-    "message": "Keep #hash in final URL",
-    "description": "Options: Label for keeping URL #hash if present."
-  },
-  "keep_hash_description": {
-    "message": "Add #hash part of mysite.com/page#hash back to shortened URL.",
-    "description": "Options: Help text for keeping URL #hash if present."
-  },
+    "keep_hash_title": {
+        "message": "Keep #hash in final URL",
+        "description": "Options: Label for keeping URL #hash if present."
+    },
+    "keep_hash_description": {
+        "message": "Add #hash part of mysite.com/page#hash back to shortened URL.",
+        "description": "Options: Help text for keeping URL #hash if present."
+    },
 
- "notify_title": {
-    "message": "成功时显示通知",
-    "description": "Options: Label for showing notification popup when URL was generated."
-  },
-  "notify_description": {
-    "message": "发生错误始终会显示通知。",
-    "description": "Options: Help text for showing notification popup on success."
-  },
+    "notify_title": {
+        "message": "成功时显示通知",
+        "description": "Options: Label for showing notification popup when URL was generated."
+    },
+    "notify_description": {
+        "message": "发生错误始终会显示通知。",
+        "description": "Options: Help text for showing notification popup on success."
+    },
 
-  "copy_title_title": {
-    "message": "Copy page title in addition to URL",
-    "description": "Options: Label for copying page title along with URL."
-  },
-  "copy_title_description": {
-    "message": "Example: 'So why are Pandas so cute? http://nyti.ms/2xGSRyh'",
-    "description": "Options: Help text for copying page title with URL."
-  },
+    "copy_title_title": {
+        "message": "Copy page title in addition to URL",
+        "description": "Options: Label for copying page title along with URL."
+    },
+    "copy_title_description": {
+        "message": "Example: 'So why are Pandas so cute? http://nyti.ms/2xGSRyh'",
+        "description": "Options: Help text for copying page title with URL."
+    },
 
- "save_button": {
-    "message": "保存",
-    "description": "Options: Button label for save options."
-  },
-  "saved_notice": {
-    "message": "Saved!",
-    "description": "Options: Indicator that options were saved."
-  }
+    "save_button": {
+        "message": "保存",
+        "description": "Options: Button label for save options."
+    },
+    "saved_notice": {
+        "message": "Saved!",
+        "description": "Options: Indicator that options were saved."
+    }
 }

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -1,163 +1,163 @@
 {
-    "extensionDescription": {
-        "message": "偵測或建立目前頁面的縮址。",
-        "description": "Detect or create a short URL for the current page."
-    },
-    "extensionName": {
-        "message": "Copy ShortURL",
-        "description": "name of extension"
-    },
-    "browserAction_label": {
-        "message": "複製縮址",
-        "description": "Toolbar button label text."
-    },
-    "menuitem_label": {
-        "message": "複製縮址",
-        "description": "Context menu item label text for page."
-    },
-    "shorten_link_label": {
-        "message": "為此連結複製縮址",
-        "description": "Context menu item label text for link."
-    },
-    "shorten_img_label": {
-        "message": "為此影像複製縮址",
-        "description": "Context menu item label text for image."
-    },
+  "extensionDescription": {
+    "message": "偵測或建立目前頁面的縮址。",
+    "description": "Detect or create a short URL for the current page."
+  },
+  "extensionName": {
+    "message": "Copy ShortURL",
+    "description": "name of extension"
+  },
+  "browserAction_label": {
+    "message": "複製縮址",
+    "description": "Toolbar button label text."
+  },
+  "menuitem_label": {
+    "message": "複製縮址",
+    "description": "Context menu item label text for page."
+  },
+  "shorten_link_label": {
+    "message": "為此連結複製縮址",
+    "description": "Context menu item label text for link."
+  },
+  "shorten_img_label": {
+    "message": "為此影像複製縮址",
+    "description": "Context menu item label text for image."
+  },
 
-    "shorten_error": {
-        "message": "噢不，建立縮址時發生錯誤。",
-        "description": "Error message when shortening URL was unsuccessful."
-    },
-    "apikey_error": {
-        "message": "偏好設定中沒有輸入 API 金鑰。",
-        "description": "Error message when shortening service needs an API key and none was provided."
-    },
-    "error_host_permission": {
-        "message": "抱歉，頁面受到瀏覽器限制無法建立縮址。",
-        "description": "Error message when running on about: or addons.mozilla.org."
-    },
+  "shorten_error": {
+    "message": "噢不，建立縮址時發生錯誤。",
+    "description": "Error message when shortening URL was unsuccessful."
+  },
+  "apikey_error": {
+    "message": "偏好設定中沒有輸入 API 金鑰。",
+    "description": "Error message when shortening service needs an API key and none was provided."
+  },
+  "error_host_permission": {
+    "message": "抱歉，頁面受到瀏覽器限制無法建立縮址。",
+    "description": "Error message when running on about: or addons.mozilla.org."
+  },
 
-    "service_title": {
-        "message": "URL 縮址服務",
-        "description": "Options: Label for selecting which service (is.gd, ...) to use."
-    },
-    "service_none": {
-        "message": "（不使用外部服務）",
-        "description": "Options: No shortening service, copy found short URL or full URL only."
-    },
-    "service_custom": {
-        "message": "自訂 （下方設定）",
-        "description": "Options: Placeholder for custom URL option in dropdown."
-    },
-    "bitly_apikey_title": {
-        "message": "Bitly API 金鑰",
-        "description": "Options: Label for Bitly API key text field."
-    },
-    "bitly_apikey_description": {
-        "message": "建立 Bitly API 金鑰",
-        "description": "Options: Link to generate Bitly API key."
-    },
-    "kuttit_apikey_title": {
-        "message": "Kutt.it API 金鑰",
-        "description": "Options: Label for Kutt.it API key text field."
-    },
-    "kuttit_apikey_description": {
-        "message": "建立 Kutt.it 的 API 金鑰",
-        "description": "Options: Link to generate Kutt.it API key."
-    },
-    "kuttit_domain_title": {
-        "message": "Kutt.it 自定義網域",
-        "description": "Options: Label for Kutt.it custom domain text field."
-    },
-    "kuttit_domain_description": {
-        "message": "(選填) 使用 Kutt.it 的自定義網域",
-        "description": "Options: Link to set Kutt.it custom domain."
-    },
-    "tly_apikey_title": {
-        "message": "t.ly API 金鑰",
-        "description": "Options: Label for t.ly API key text field."
-    },
-    "tly_apikey_description": {
-        "message": "建立 t.ly 的 API 金鑰",
-        "description": "Options: Link to generate t.ly API key."
-    },
-    "tly_domain_title": {
-        "message": "t.ly 自定義網域",
-        "description": "Options: Label for t.ly custom domain text field."
-    },
-    "tly_domain_description": {
-        "message": "(選填) 使用 t.ly 的自定義網域",
-        "description": "Options: Link to set t.ly custom domain."
-    },
-    "customurl_title": {
-        "message": "自訂縮址服務 URL",
-        "description": "Options: Label for custom URL text field."
-    },
-    "customurl_description": {
-        "message": "使用 %URL% 替代原始 URL 的位置。",
-        "description": "Options: Help text for custom URL."
-    },
+  "service_title": {
+    "message": "URL 縮址服務",
+    "description": "Options: Label for selecting which service (is.gd, ...) to use."
+  },
+  "service_none": {
+    "message": "（不使用外部服務）",
+    "description": "Options: No shortening service, copy found short URL or full URL only."
+  },
+  "service_custom": {
+    "message": "自訂 （下方設定）",
+    "description": "Options: Placeholder for custom URL option in dropdown."
+  },
+  "bitly_apikey_title": {
+    "message": "Bitly API 金鑰",
+    "description": "Options: Label for Bitly API key text field."
+  },
+  "bitly_apikey_description": {
+    "message": "建立 Bitly API 金鑰",
+    "description": "Options: Link to generate Bitly API key."
+  },
+  "kuttit_apikey_title": {
+    "message": "Kutt.it API 金鑰",
+    "description": "Options: Label for Kutt.it API key text field."
+  },
+  "kuttit_apikey_description": {
+    "message": "建立 Kutt.it 的 API 金鑰",
+    "description": "Options: Link to generate Kutt.it API key."
+  },
+  "kuttit_domain_title": {
+    "message": "Kutt.it 自定義網域",
+    "description": "Options: Label for Kutt.it custom domain text field."
+  },
+  "kuttit_domain_description": {
+    "message": "(選填) 使用 Kutt.it 的自定義網域",
+    "description": "Options: Link to set Kutt.it custom domain."
+  },
+  "tly_apikey_title": {
+    "message": "t.ly API 金鑰",
+    "description": "Options: Label for t.ly API key text field."
+  },
+  "tly_apikey_description": {
+    "message": "建立 t.ly 的 API 金鑰",
+    "description": "Options: Link to generate t.ly API key."
+  },
+  "tly_domain_title": {
+    "message": "t.ly 自定義網域",
+    "description": "Options: Label for t.ly custom domain text field."
+  },
+  "tly_domain_description": {
+    "message": "(選填) 使用 t.ly 的自定義網域",
+    "description": "Options: Link to set t.ly custom domain."
+  },
+  "customurl_title": {
+    "message": "自訂縮址服務 URL",
+    "description": "Options: Label for custom URL text field."
+  },
+  "customurl_description": {
+    "message": "使用 %URL% 替代原始 URL 的位置。",
+    "description": "Options: Help text for custom URL."
+  },
 
-    "shorten_canonical_title": {
-        "message": "當網址超過以下設定長度時才縮址。",
-        "description": "Options: Label for maximum URL length before forcing shortening."
-    },
-    "shorten_canonical_description": {
-        "message": "部份網站如果未達設定長度不會進行縮址。 這裡設定當超過一定長度時才使用縮址服務（0 =  不縮址）。",
-        "description": "Options: Help text for forcing shortening of long canonical URLs."
-    },
+  "shorten_canonical_title": {
+    "message": "當網址超過以下設定長度時才縮址。",
+    "description": "Options: Label for maximum URL length before forcing shortening."
+  },
+  "shorten_canonical_description": {
+    "message": "部份網站如果未達設定長度不會進行縮址。 這裡設定當超過一定長度時才使用縮址服務（0 =  不縮址）。",
+    "description": "Options: Help text for forcing shortening of long canonical URLs."
+  },
 
-    "use_special_title": {
-        "message": "在已知網站中使用特定縮址格式",
-        "description": "Options: Label for using youtu.be and other special known short URLs."
-    },
-    "use_special_description": {
-        "message": "有些網站有自己的縮址服務，像是 youtu.be。",
-        "description": "Options: Help text for using special shortening cases."
-    },
+  "use_special_title": {
+    "message": "在已知網站中使用特定縮址格式",
+    "description": "Options: Label for using youtu.be and other special known short URLs."
+  },
+  "use_special_description": {
+    "message": "有些網站有自己的縮址服務，像是 youtu.be。",
+    "description": "Options: Help text for using special shortening cases."
+  },
 
-    "strip_utm_title": {
-        "message": "移除網址中的 ?utm_* 參數",
-        "description": "Options: Label for removing known marketing parameters from URLs."
-    },
-    "strip_utm_description": {
-        "message": "商業活動中常常會在 URL 中加入 ?utm_campaign=something ，這可以移除。",
-        "description": "Options: Help text for removing known marketing parameters from URL."
-    },
+  "strip_utm_title": {
+    "message": "移除網址中的 ?utm_* 參數",
+    "description": "Options: Label for removing known marketing parameters from URLs."
+  },
+  "strip_utm_description": {
+    "message": "商業活動中常常會在 URL 中加入 ?utm_campaign=something ，這可以移除。",
+    "description": "Options: Help text for removing known marketing parameters from URL."
+  },
 
-    "keep_hash_title": {
-        "message": "在網址中保留 #hash",
-        "description": "Options: Label for keeping URL #hash if present."
-    },
-    "keep_hash_description": {
-        "message": "將網址中 #hash 的部份一起加入縮址，像是 mysite.com/page#hash。",
-        "description": "Options: Help text for keeping URL #hash if present."
-    },
+  "keep_hash_title": {
+    "message": "在網址中保留 #hash",
+    "description": "Options: Label for keeping URL #hash if present."
+  },
+  "keep_hash_description": {
+    "message": "將網址中 #hash 的部份一起加入縮址，像是 mysite.com/page#hash。",
+    "description": "Options: Help text for keeping URL #hash if present."
+  },
 
-    "notify_title": {
-        "message": "成功時顯示通知",
-        "description": "Options: Label for showing notification popup when URL was generated."
-    },
-    "notify_description": {
-        "message": "失敗時無論如何都會顯示通知。",
-        "description": "Options: Help text for showing notification popup on success."
-    },
+  "notify_title": {
+    "message": "成功時顯示通知",
+    "description": "Options: Label for showing notification popup when URL was generated."
+  },
+  "notify_description": {
+    "message": "失敗時無論如何都會顯示通知。",
+    "description": "Options: Help text for showing notification popup on success."
+  },
 
-    "copy_title_title": {
-        "message": "複製時連同網頁標題一起複製",
-        "description": "Options: Label for copying page title along with URL."
-    },
-    "copy_title_description": {
-        "message": "像是： 'So why are Pandas so cute? http://nyti.ms/2xGSRyh'",
-        "description": "Options: Help text for copying page title with URL."
-    },
+  "copy_title_title": {
+    "message": "複製時連同網頁標題一起複製",
+    "description": "Options: Label for copying page title along with URL."
+  },
+  "copy_title_description": {
+    "message": "像是： 'So why are Pandas so cute? http://nyti.ms/2xGSRyh'",
+    "description": "Options: Help text for copying page title with URL."
+  },
 
-    "save_button": {
-        "message": "儲存",
-        "description": "Options: Button label for save options."
-    },
-    "saved_notice": {
-        "message": "已儲存！",
-        "description": "Options: Indicator that options were saved."
-    }
+  "save_button": {
+    "message": "儲存",
+    "description": "Options: Button label for save options."
+  },
+  "saved_notice": {
+    "message": "已儲存！",
+    "description": "Options: Indicator that options were saved."
+  }
 }

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -1,147 +1,163 @@
 {
-  "extensionDescription": {
-    "message": "偵測或建立目前頁面的縮址。",
-    "description": "Detect or create a short URL for the current page."
-  },
-  "extensionName": {
-    "message": "Copy ShortURL",
-    "description": "name of extension"
-  },
-  "browserAction_label": {
-    "message": "複製縮址",
-    "description": "Toolbar button label text."
-  },
-  "menuitem_label": {
-    "message": "複製縮址",
-    "description": "Context menu item label text for page."
-  },
-  "shorten_link_label": {
-    "message": "為此連結複製縮址",
-    "description": "Context menu item label text for link."
-  },
-  "shorten_img_label": {
-    "message": "為此影像複製縮址",
-    "description": "Context menu item label text for image."
-  },
+    "extensionDescription": {
+        "message": "偵測或建立目前頁面的縮址。",
+        "description": "Detect or create a short URL for the current page."
+    },
+    "extensionName": {
+        "message": "Copy ShortURL",
+        "description": "name of extension"
+    },
+    "browserAction_label": {
+        "message": "複製縮址",
+        "description": "Toolbar button label text."
+    },
+    "menuitem_label": {
+        "message": "複製縮址",
+        "description": "Context menu item label text for page."
+    },
+    "shorten_link_label": {
+        "message": "為此連結複製縮址",
+        "description": "Context menu item label text for link."
+    },
+    "shorten_img_label": {
+        "message": "為此影像複製縮址",
+        "description": "Context menu item label text for image."
+    },
 
-  "shorten_error": {
-    "message": "噢不，建立縮址時發生錯誤。",
-    "description": "Error message when shortening URL was unsuccessful."
-  },
-  "apikey_error": {
-    "message": "偏好設定中沒有輸入 API 金鑰。",
-    "description": "Error message when shortening service needs an API key and none was provided."
-  },
-  "error_host_permission": {
-    "message": "抱歉，頁面受到瀏覽器限制無法建立縮址。",
-    "description": "Error message when running on about: or addons.mozilla.org."
-  },
+    "shorten_error": {
+        "message": "噢不，建立縮址時發生錯誤。",
+        "description": "Error message when shortening URL was unsuccessful."
+    },
+    "apikey_error": {
+        "message": "偏好設定中沒有輸入 API 金鑰。",
+        "description": "Error message when shortening service needs an API key and none was provided."
+    },
+    "error_host_permission": {
+        "message": "抱歉，頁面受到瀏覽器限制無法建立縮址。",
+        "description": "Error message when running on about: or addons.mozilla.org."
+    },
 
-  "service_title": {
-    "message": "URL 縮址服務",
-    "description": "Options: Label for selecting which service (is.gd, ...) to use."
-  },
-  "service_none": {
-    "message": "（不使用外部服務）",
-    "description": "Options: No shortening service, copy found short URL or full URL only."
-  },
-  "service_custom": {
-    "message": "自訂 （下方設定）",
-    "description": "Options: Placeholder for custom URL option in dropdown."
-  },
-  "bitly_apikey_title": {
-    "message": "Bitly API 金鑰",
-    "description": "Options: Label for Bitly API key text field."
-  },
-  "bitly_apikey_description": {
-    "message": "建立 Bitly API 金鑰",
-    "description": "Options: Link to generate Bitly API key."
-  },
-  "kuttit_apikey_title": {
-    "message": "Kutt.it API Key",
-    "description": "Options: Label for Kutt.it API key text field."
-  },
-  "kuttit_apikey_description": {
-    "message": "Generate an API key with Kutt.it",
-    "description": "Options: Link to generate Kutt.it API key."
-  },
-  "kuttit_domain_title": {
-    "message": "Kutt.it Custom Domain",
-    "description": "Options: Label for Kutt.it custom domain text field."
-  },
-  "kuttit_domain_description": {
-    "message": "(optional) use a custom domain with kutt.it",
-    "description": "Options: Link to set Kutt.it custom domain."
-  },
-  "customurl_title": {
-    "message": "自訂縮址服務 URL",
-    "description": "Options: Label for custom URL text field."
-  },
-  "customurl_description": {
-    "message": "使用 %URL% 替代原始 URL 的位置。",
-    "description": "Options: Help text for custom URL."
-  },
+    "service_title": {
+        "message": "URL 縮址服務",
+        "description": "Options: Label for selecting which service (is.gd, ...) to use."
+    },
+    "service_none": {
+        "message": "（不使用外部服務）",
+        "description": "Options: No shortening service, copy found short URL or full URL only."
+    },
+    "service_custom": {
+        "message": "自訂 （下方設定）",
+        "description": "Options: Placeholder for custom URL option in dropdown."
+    },
+    "bitly_apikey_title": {
+        "message": "Bitly API 金鑰",
+        "description": "Options: Label for Bitly API key text field."
+    },
+    "bitly_apikey_description": {
+        "message": "建立 Bitly API 金鑰",
+        "description": "Options: Link to generate Bitly API key."
+    },
+    "kuttit_apikey_title": {
+        "message": "Kutt.it API 金鑰",
+        "description": "Options: Label for Kutt.it API key text field."
+    },
+    "kuttit_apikey_description": {
+        "message": "建立 Kutt.it 的 API 金鑰",
+        "description": "Options: Link to generate Kutt.it API key."
+    },
+    "kuttit_domain_title": {
+        "message": "Kutt.it 自定義網域",
+        "description": "Options: Label for Kutt.it custom domain text field."
+    },
+    "kuttit_domain_description": {
+        "message": "(選填) 使用 Kutt.it 的自定義網域",
+        "description": "Options: Link to set Kutt.it custom domain."
+    },
+    "tly_apikey_title": {
+        "message": "t.ly API 金鑰",
+        "description": "Options: Label for t.ly API key text field."
+    },
+    "tly_apikey_description": {
+        "message": "建立 t.ly 的 API 金鑰",
+        "description": "Options: Link to generate t.ly API key."
+    },
+    "tly_domain_title": {
+        "message": "t.ly 自定義網域",
+        "description": "Options: Label for t.ly custom domain text field."
+    },
+    "tly_domain_description": {
+        "message": "(選填) 使用 t.ly 的自定義網域",
+        "description": "Options: Link to set t.ly custom domain."
+    },
+    "customurl_title": {
+        "message": "自訂縮址服務 URL",
+        "description": "Options: Label for custom URL text field."
+    },
+    "customurl_description": {
+        "message": "使用 %URL% 替代原始 URL 的位置。",
+        "description": "Options: Help text for custom URL."
+    },
 
-  "shorten_canonical_title": {
-    "message": "當網址超過以下設定長度時才縮址。",
-    "description": "Options: Label for maximum URL length before forcing shortening."
-  },
-  "shorten_canonical_description": {
-    "message": "部份網站如果未達設定長度不會進行縮址。 這裡設定當超過一定長度時才使用縮址服務（0 =  不縮址）。",
-    "description": "Options: Help text for forcing shortening of long canonical URLs."
-  },
+    "shorten_canonical_title": {
+        "message": "當網址超過以下設定長度時才縮址。",
+        "description": "Options: Label for maximum URL length before forcing shortening."
+    },
+    "shorten_canonical_description": {
+        "message": "部份網站如果未達設定長度不會進行縮址。 這裡設定當超過一定長度時才使用縮址服務（0 =  不縮址）。",
+        "description": "Options: Help text for forcing shortening of long canonical URLs."
+    },
 
-  "use_special_title": {
-    "message": "在已知網站中使用特定縮址格式",
-    "description": "Options: Label for using youtu.be and other special known short URLs."
-  },
-  "use_special_description": {
-    "message": "有些網站有自己的縮址服務，像是 youtu.be。",
-    "description": "Options: Help text for using special shortening cases."
-  },
+    "use_special_title": {
+        "message": "在已知網站中使用特定縮址格式",
+        "description": "Options: Label for using youtu.be and other special known short URLs."
+    },
+    "use_special_description": {
+        "message": "有些網站有自己的縮址服務，像是 youtu.be。",
+        "description": "Options: Help text for using special shortening cases."
+    },
 
-  "strip_utm_title": {
-    "message": "移除網址中的 ?utm_* 參數",
-    "description": "Options: Label for removing known marketing parameters from URLs."
-  },
-  "strip_utm_description": {
-    "message": "商業活動中常常會在 URL 中加入 ?utm_campaign=something ，這可以移除。",
-    "description": "Options: Help text for removing known marketing parameters from URL."
-  },
+    "strip_utm_title": {
+        "message": "移除網址中的 ?utm_* 參數",
+        "description": "Options: Label for removing known marketing parameters from URLs."
+    },
+    "strip_utm_description": {
+        "message": "商業活動中常常會在 URL 中加入 ?utm_campaign=something ，這可以移除。",
+        "description": "Options: Help text for removing known marketing parameters from URL."
+    },
 
-  "keep_hash_title": {
-    "message": "在網址中保留 #hash",
-    "description": "Options: Label for keeping URL #hash if present."
-  },
-  "keep_hash_description": {
-    "message": "將網址中 #hash 的部份一起加入縮址，像是 mysite.com/page#hash。",
-    "description": "Options: Help text for keeping URL #hash if present."
-  },
+    "keep_hash_title": {
+        "message": "在網址中保留 #hash",
+        "description": "Options: Label for keeping URL #hash if present."
+    },
+    "keep_hash_description": {
+        "message": "將網址中 #hash 的部份一起加入縮址，像是 mysite.com/page#hash。",
+        "description": "Options: Help text for keeping URL #hash if present."
+    },
 
- "notify_title": {
-    "message": "成功時顯示通知",
-    "description": "Options: Label for showing notification popup when URL was generated."
-  },
-  "notify_description": {
-    "message": "失敗時無論如何都會顯示通知。",
-    "description": "Options: Help text for showing notification popup on success."
-  },
+    "notify_title": {
+        "message": "成功時顯示通知",
+        "description": "Options: Label for showing notification popup when URL was generated."
+    },
+    "notify_description": {
+        "message": "失敗時無論如何都會顯示通知。",
+        "description": "Options: Help text for showing notification popup on success."
+    },
 
- "copy_title_title": {
-    "message": "複製時連同網頁標題一起複製",
-    "description": "Options: Label for copying page title along with URL."
-  },
-  "copy_title_description": {
-    "message": "像是： 'So why are Pandas so cute? http://nyti.ms/2xGSRyh'",
-    "description": "Options: Help text for copying page title with URL."
-  },
+    "copy_title_title": {
+        "message": "複製時連同網頁標題一起複製",
+        "description": "Options: Label for copying page title along with URL."
+    },
+    "copy_title_description": {
+        "message": "像是： 'So why are Pandas so cute? http://nyti.ms/2xGSRyh'",
+        "description": "Options: Help text for copying page title with URL."
+    },
 
-  "save_button": {
-    "message": "儲存",
-    "description": "Options: Button label for save options."
-  },
-  "saved_notice": {
-    "message": "已儲存！",
-    "description": "Options: Indicator that options were saved."
-  }
+    "save_button": {
+        "message": "儲存",
+        "description": "Options: Button label for save options."
+    },
+    "saved_notice": {
+        "message": "已儲存！",
+        "description": "Options: Indicator that options were saved."
+    }
 }

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -58,20 +58,36 @@
     "description": "Options: Link to generate Bitly API key."
   },
   "kuttit_apikey_title": {
-    "message": "Kutt.it API Key",
+    "message": "Kutt.it API 金鑰",
     "description": "Options: Label for Kutt.it API key text field."
   },
   "kuttit_apikey_description": {
-    "message": "Generate an API key with Kutt.it",
+    "message": "建立 Kutt.it 的 API 金鑰",
     "description": "Options: Link to generate Kutt.it API key."
   },
   "kuttit_domain_title": {
-    "message": "Kutt.it Custom Domain",
+    "message": "Kutt.it 自定義網域",
     "description": "Options: Label for Kutt.it custom domain text field."
   },
   "kuttit_domain_description": {
-    "message": "(optional) use a custom domain with kutt.it",
+    "message": "(選填) 使用 Kutt.it 的自定義網域",
     "description": "Options: Link to set Kutt.it custom domain."
+  },
+  "tly_apikey_title": {
+    "message": "t.ly API 金鑰",
+    "description": "Options: Label for t.ly API key text field."
+  },
+  "tly_apikey_description": {
+    "message": "建立 t.ly 的 API 金鑰",
+    "description": "Options: Link to generate t.ly API key."
+  },
+  "tly_domain_title": {
+    "message": "t.ly 自定義網域",
+    "description": "Options: Label for t.ly custom domain text field."
+  },
+  "tly_domain_description": {
+    "message": "(選填) 使用 t.ly 的自定義網域",
+    "description": "Options: Link to set t.ly custom domain."
   },
   "customurl_title": {
     "message": "自訂縮址服務 URL",

--- a/src/data/html/options.html
+++ b/src/data/html/options.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <style>
-    body {
-      background-color: white;
-      padding: 1em;
-    }
-    label[for], p em {
-      display: block;
-    }
-    input[type=checkbox] {
-      float: left;
-      margin-right: 1em;
-    }
-    p {
-      margin-bottom: 2em;
-    }
-    #saved {
-      font-weight: bold;
-    }
+      body {
+        background-color: white;
+        padding: 1em;
+      }
+      label[for],
+      p em {
+        display: block;
+      }
+      input[type='checkbox'] {
+        float: left;
+        margin-right: 1em;
+      }
+      p {
+        margin-bottom: 2em;
+      }
+      #saved {
+        font-weight: bold;
+      }
     </style>
   </head>
 
@@ -31,7 +32,9 @@
         <select id="service">
           <option value="none" data-i18n="service_none">none</option>
           <!--<option value="isgd">is.gd (https://is.gd/abcde)</option>-->
-          <option value="tinyurl">tinyurl.com (https://tinyurl.com/abcde)</option>
+          <option value="tinyurl">
+            tinyurl.com (https://tinyurl.com/abcde)
+          </option>
           <option value="cuttly">cutt.ly (https://cutt.ly/abcde)</option>
           <option value="goly">go.ly (https://go.ly/abcde)</option>
           <option value="vurl">vurl.com (https://vurl.com/abcde)</option>
@@ -43,88 +46,113 @@
       </p>
 
       <!-- Bitly API key -->
-      <p id="bitly_details" style="display:none">
-        <label for="bitly_apikey" data-i18n="bitly_apikey_title">bitly api key</label>
-        <input type="password" id="bitly_apikey">
-        <a href="https://app.bitly.com/settings/api/"><em data-i18n="bitly_apikey_description">acquire API key</em></a>
+      <p id="bitly_details" style="display: none">
+        <label for="bitly_apikey" data-i18n="bitly_apikey_title"
+          >bitly api key</label
+        >
+        <input type="password" id="bitly_apikey" />
+        <a href="https://app.bitly.com/settings/api/"
+          ><em data-i18n="bitly_apikey_description">acquire API key</em></a
+        >
       </p>
 
       <!-- Kutt.it API key -->
-      <p id="kuttit_details" style="display:none">
-        <label for="kuttit_apikey" data-i18n="kuttit_apikey_title">kutt.it api key</label>
-        <input type="password" id="kuttit_apikey">
-        <a href="https://kutt.it/settings"><em data-i18n="kuttit_apikey_description">Acquire API key</em></a>
+      <p id="kuttit_details" style="display: none">
+        <label for="kuttit_apikey" data-i18n="kuttit_apikey_title"
+          >kutt.it api key</label
+        >
+        <input type="password" id="kuttit_apikey" />
+        <a href="https://kutt.it/settings"
+          ><em data-i18n="kuttit_apikey_description">Acquire API key</em></a
+        >
 
-        <label for="kuttit_domain" data-i18n="kuttit_domain_title">kutt.it domain</label>
-        <input type="text" id="kuttit_domain">
-        <a href="https://kutt.it/settings"><em data-i18n="kuttit_domain_description">Kutt.it custom domain</em></a>
+        <label for="kuttit_domain" data-i18n="kuttit_domain_title"
+          >kutt.it domain</label
+        >
+        <input type="text" id="kuttit_domain" />
+        <a href="https://kutt.it/settings"
+          ><em data-i18n="kuttit_domain_description"
+            >Kutt.it custom domain</em
+          ></a
+        >
       </p>
 
       <!-- t.ly API key -->
-      <p id="tly_details" style="display:none">
-        <label for="tly_apikey" data-i18n="tly_apikey_title">t.ly api key</label>
-        <input type="password" id="tly_apikey">
-        <a href="https://t.ly/settings#/api"><em data-i18n="tly_apikey_description">Acquire API key</em></a>
+      <p id="tly_details" style="display: none">
+        <label for="tly_apikey" data-i18n="tly_apikey_title"
+          >t.ly api key</label
+        >
+        <input type="password" id="tly_apikey" />
+        <a href="https://t.ly/settings#/api"
+          ><em data-i18n="tly_apikey_description">Acquire API key</em></a
+        >
 
         <label for="tly_domain" data-i18n="tly_domain_title">t.ly domain</label>
-        <input type="text" id="tly_domain">
-        <a href="https://t.ly/settings#/domain"><em data-i18n="tly_domain_description">t.ly custom domain</em></a>
+        <input type="text" id="tly_domain" />
+        <a href="https://t.ly/settings#/domain"
+          ><em data-i18n="tly_domain_description">t.ly custom domain</em></a
+        >
       </p>
 
       <!-- Custom URL + documentation link -->
-      <p id="custom_details" style="display:none">
+      <p id="custom_details" style="display: none">
         <label for="custom_url" data-i18n="customurl_title">custom url</label>
-        <input type="text" id="custom_url">
+        <input type="text" id="custom_url" />
         <em data-i18n="customurl_description">%URL%</em>
       </p>
 
       <!-- Shorten canconical -->
       <p id="always_shorten">
-        <label for="shorten_canonical" data-i18n="shorten_canonical_title">Max len</label>
-        <input type="number" id="shorten_canonical" min="0" value="0">
+        <label for="shorten_canonical" data-i18n="shorten_canonical_title"
+          >Max len</label
+        >
+        <input type="number" id="shorten_canonical" min="0" value="0" />
         <em data-i18n="shorten_canonical_description">0 = never</em>
       </p>
 
       <!-- Use special, known shorteners? -->
       <p>
-        <input type="checkbox" id="use_special">
-        <label for="use_special" data-i18n="use_special_title">use special?</label>
+        <input type="checkbox" id="use_special" />
+        <label for="use_special" data-i18n="use_special_title"
+          >use special?</label
+        >
         <em data-i18n="use_special_description">youtu.be</em>
       </p>
 
       <!-- Strip utm (note, misspelled as urm, oops) -->
       <p>
-        <input type="checkbox" id="strip_urm">
+        <input type="checkbox" id="strip_urm" />
         <label for="strip_urm" data-i18n="strip_utm_title">strip utm</label>
         <em data-i18n="strip_utm_description">urm marketing parameters</em>
       </p>
 
       <!-- Add #hash if present -->
       <p>
-        <input type="checkbox" id="keep_hash">
+        <input type="checkbox" id="keep_hash" />
         <label for="keep_hash" data-i18n="keep_hash_title">keep hash</label>
         <em data-i18n="keep_hash_description">url #hash</em>
       </p>
 
       <!-- Show notification? -->
       <p>
-        <input type="checkbox" id="notify">
+        <input type="checkbox" id="notify" />
         <label for="notify" data-i18n="notify_title">notify?</label>
         <em data-i18n="notify_description">notify on URL</em>
       </p>
 
       <!-- Copy title + URL or just URL? -->
       <p>
-        <input type="checkbox" id="copy_title">
+        <input type="checkbox" id="copy_title" />
         <label for="copy_title" data-i18n="copy_title_title">copy title?</label>
         <em data-i18n="copy_title_description">copy page title</em>
       </p>
 
       <p>
         <button type="submit" data-i18n="save_button">Save</button>
-        <span id="saved" style="display:none" data-i18n="saved_notice">(saved)</span>
+        <span id="saved" style="display: none" data-i18n="saved_notice"
+          >(saved)</span
+        >
       </p>
-
     </form>
 
     <script src="../js/options.js"></script>

--- a/src/data/html/options.html
+++ b/src/data/html/options.html
@@ -37,6 +37,7 @@
           <option value="vurl">vurl.com (https://vurl.com/abcde)</option>
           <option value="bitly">bit.ly (http://bit.ly/abcde)</option>
           <option value="kuttit">kutt.it (http://kutt.it/abcde)</option>
+          <option value="tly">t.ly (https://t.ly/abcde)</option>
           <option value="custom" data-i18n="service_custom">custom</option>
         </select>
       </p>
@@ -57,6 +58,17 @@
         <label for="kuttit_domain" data-i18n="kuttit_domain_title">kutt.it domain</label>
         <input type="text" id="kuttit_domain">
         <a href="https://kutt.it/settings"><em data-i18n="kuttit_domain_description">Kutt.it custom domain</em></a>
+      </p>
+
+      <!-- t.ly API key -->
+      <p id="tly_details" style="display: none">
+        <label for="tly_apikey" data-i18n="tly_apikey_title">t.ly api key</label>
+        <input type="password" id="tly_apikey" />
+        <a href="https://t.ly/settings#/api"><em data-i18n="tly_apikey_description">Acquire API key</em></a>
+      
+        <label for="tly_domain" data-i18n="tly_domain_title">t.ly domain</label>
+        <input type="text" id="tly_domain" />
+        <a href="https://t.ly/settings#/domain"><em data-i18n="tly_domain_description">t.ly custom domain</em></a>
       </p>
 
       <!-- Custom URL + documentation link -->

--- a/src/data/html/options.html
+++ b/src/data/html/options.html
@@ -32,9 +32,7 @@
         <select id="service">
           <option value="none" data-i18n="service_none">none</option>
           <!--<option value="isgd">is.gd (https://is.gd/abcde)</option>-->
-          <option value="tinyurl">
-            tinyurl.com (https://tinyurl.com/abcde)
-          </option>
+          <option value="tinyurl">tinyurl.com (https://tinyurl.com/abcde)</option>
           <option value="cuttly">cutt.ly (https://cutt.ly/abcde)</option>
           <option value="goly">go.ly (https://go.ly/abcde)</option>
           <option value="vurl">vurl.com (https://vurl.com/abcde)</option>
@@ -47,51 +45,31 @@
 
       <!-- Bitly API key -->
       <p id="bitly_details" style="display: none">
-        <label for="bitly_apikey" data-i18n="bitly_apikey_title"
-          >bitly api key</label
-        >
+        <label for="bitly_apikey" data-i18n="bitly_apikey_title">bitly api key</label>
         <input type="password" id="bitly_apikey" />
-        <a href="https://app.bitly.com/settings/api/"
-          ><em data-i18n="bitly_apikey_description">acquire API key</em></a
-        >
+        <a href="https://app.bitly.com/settings/api/"><em data-i18n="bitly_apikey_description">acquire API key</em></a>
       </p>
 
       <!-- Kutt.it API key -->
       <p id="kuttit_details" style="display: none">
-        <label for="kuttit_apikey" data-i18n="kuttit_apikey_title"
-          >kutt.it api key</label
-        >
+        <label for="kuttit_apikey" data-i18n="kuttit_apikey_title">kutt.it api key</label>
         <input type="password" id="kuttit_apikey" />
-        <a href="https://kutt.it/settings"
-          ><em data-i18n="kuttit_apikey_description">Acquire API key</em></a
-        >
+        <a href="https://kutt.it/settings"><em data-i18n="kuttit_apikey_description">Acquire API key</em></a>
 
-        <label for="kuttit_domain" data-i18n="kuttit_domain_title"
-          >kutt.it domain</label
-        >
+        <label for="kuttit_domain" data-i18n="kuttit_domain_title">kutt.it domain</label>
         <input type="text" id="kuttit_domain" />
-        <a href="https://kutt.it/settings"
-          ><em data-i18n="kuttit_domain_description"
-            >Kutt.it custom domain</em
-          ></a
-        >
+        <a href="https://kutt.it/settings"><em data-i18n="kuttit_domain_description">Kutt.it custom domain</em></a>
       </p>
 
       <!-- t.ly API key -->
       <p id="tly_details" style="display: none">
-        <label for="tly_apikey" data-i18n="tly_apikey_title"
-          >t.ly api key</label
-        >
+        <label for="tly_apikey" data-i18n="tly_apikey_title">t.ly api key</label>
         <input type="password" id="tly_apikey" />
-        <a href="https://t.ly/settings#/api"
-          ><em data-i18n="tly_apikey_description">Acquire API key</em></a
-        >
+        <a href="https://t.ly/settings#/api"><em data-i18n="tly_apikey_description">Acquire API key</em></a>
 
         <label for="tly_domain" data-i18n="tly_domain_title">t.ly domain</label>
         <input type="text" id="tly_domain" />
-        <a href="https://t.ly/settings#/domain"
-          ><em data-i18n="tly_domain_description">t.ly custom domain</em></a
-        >
+        <a href="https://t.ly/settings#/domain"><em data-i18n="tly_domain_description">t.ly custom domain</em></a>
       </p>
 
       <!-- Custom URL + documentation link -->
@@ -103,9 +81,7 @@
 
       <!-- Shorten canconical -->
       <p id="always_shorten">
-        <label for="shorten_canonical" data-i18n="shorten_canonical_title"
-          >Max len</label
-        >
+        <label for="shorten_canonical" data-i18n="shorten_canonical_title">Max len</label>
         <input type="number" id="shorten_canonical" min="0" value="0" />
         <em data-i18n="shorten_canonical_description">0 = never</em>
       </p>
@@ -113,9 +89,7 @@
       <!-- Use special, known shorteners? -->
       <p>
         <input type="checkbox" id="use_special" />
-        <label for="use_special" data-i18n="use_special_title"
-          >use special?</label
-        >
+        <label for="use_special" data-i18n="use_special_title">use special?</label>
         <em data-i18n="use_special_description">youtu.be</em>
       </p>
 
@@ -149,9 +123,7 @@
 
       <p>
         <button type="submit" data-i18n="save_button">Save</button>
-        <span id="saved" style="display: none" data-i18n="saved_notice"
-          >(saved)</span
-        >
+        <span id="saved" style="display: none" data-i18n="saved_notice">(saved)</span>
       </p>
     </form>
 

--- a/src/data/html/options.html
+++ b/src/data/html/options.html
@@ -37,6 +37,7 @@
           <option value="vurl">vurl.com (https://vurl.com/abcde)</option>
           <option value="bitly">bit.ly (http://bit.ly/abcde)</option>
           <option value="kuttit">kutt.it (http://kutt.it/abcde)</option>
+          <option value="tly">t.ly (https://t.ly/abcde)</option>
           <option value="custom" data-i18n="service_custom">custom</option>
         </select>
       </p>
@@ -57,6 +58,17 @@
         <label for="kuttit_domain" data-i18n="kuttit_domain_title">kutt.it domain</label>
         <input type="text" id="kuttit_domain">
         <a href="https://kutt.it/settings"><em data-i18n="kuttit_domain_description">Kutt.it custom domain</em></a>
+      </p>
+
+      <!-- t.ly API key -->
+      <p id="tly_details" style="display:none">
+        <label for="tly_apikey" data-i18n="tly_apikey_title">t.ly api key</label>
+        <input type="password" id="tly_apikey">
+        <a href="https://t.ly/settings#/api"><em data-i18n="tly_apikey_description">Acquire API key</em></a>
+
+        <label for="tly_domain" data-i18n="tly_domain_title">t.ly domain</label>
+        <input type="text" id="tly_domain">
+        <a href="https://t.ly/settings#/domain"><em data-i18n="tly_domain_description">t.ly custom domain</em></a>
       </p>
 
       <!-- Custom URL + documentation link -->

--- a/src/data/js/options.js
+++ b/src/data/js/options.js
@@ -1,105 +1,112 @@
 const options = {
-  service: {
-    attr: 'value',
-    def: 'isgd'
-  },
-  bitly_apikey: {
-    attr: 'value',
-    def: ''
-  },
-  kuttit_apikey: {
-    attr: 'value',
-    def: ''
-  },
-  kuttit_domain: {
-    attr: 'value',
-    def: ''
-  },
-  custom_url: {
-    attr: 'value',
-    def: ''
-  },
-  shorten_canonical: {
-    attr: 'value',
-    def: 30
-  },
-  use_special: {
-    attr: 'checked',
-    def: true
-  },
-  strip_urm: {
-    attr: 'checked',
-    def: true
-  },
-  keep_hash: {
-    attr: 'checked',
-    def: false
-  },
-  notify: {
-    attr: 'checked',
-    def: true
-  },
-  copy_title: {
-    attr: 'checked',
-    def: false
-  }
-}
+    service: {
+        attr: 'value',
+        def: 'isgd',
+    },
+    bitly_apikey: {
+        attr: 'value',
+        def: '',
+    },
+    kuttit_apikey: {
+        attr: 'value',
+        def: '',
+    },
+    kuttit_domain: {
+        attr: 'value',
+        def: '',
+    },
+    tly_apikey: {
+        attr: 'value',
+        def: '',
+    },
+    tly_domain: {
+        attr: 'value',
+        def: '',
+    },
+    custom_url: {
+        attr: 'value',
+        def: '',
+    },
+    shorten_canonical: {
+        attr: 'value',
+        def: 30,
+    },
+    use_special: {
+        attr: 'checked',
+        def: true,
+    },
+    strip_urm: {
+        attr: 'checked',
+        def: true,
+    },
+    keep_hash: {
+        attr: 'checked',
+        def: false,
+    },
+    notify: {
+        attr: 'checked',
+        def: true,
+    },
+    copy_title: {
+        attr: 'checked',
+        def: false,
+    },
+};
 let savedTimeout; // Hide saved indicator after a bit.
 
-
 function init() {
-  // Initialize i18n.
-  document.querySelectorAll('[data-i18n]').forEach(node => {
-    node.textContent = browser.i18n.getMessage(node.dataset.i18n);
-  });
-
-  // Restore settings.
-  browser.storage.local.get('prefs').then(res => {
-    let currentPrefs = res['prefs'] || {};
-    Object.keys(options).forEach(id => {
-      let val = (typeof currentPrefs[id] !== 'undefined') ? currentPrefs[id] : options[id].def;
-      document.getElementById(id)[options[id].attr] = val;
+    // Initialize i18n.
+    document.querySelectorAll('[data-i18n]').forEach((node) => {
+        node.textContent = browser.i18n.getMessage(node.dataset.i18n);
     });
 
-    showHideDetails();
-  });
+    // Restore settings.
+    browser.storage.local.get('prefs').then((res) => {
+        let currentPrefs = res['prefs'] || {};
+        Object.keys(options).forEach((id) => {
+            let val = typeof currentPrefs[id] !== 'undefined' ? currentPrefs[id] : options[id].def;
+            document.getElementById(id)[options[id].attr] = val;
+        });
 
-  document.querySelector('#service').addEventListener('change', showHideDetails);
+        showHideDetails();
+    });
+
+    document.querySelector('#service').addEventListener('change', showHideDetails);
 }
 
 function showHideDetails() {
-  // Show / hide details depending on service selection.
-  let selected = document.querySelector('#service').value;
+    // Show / hide details depending on service selection.
+    let selected = document.querySelector('#service').value;
 
-  ['bitly', 'kuttit', 'custom'].forEach(service => {
-    document.querySelector('#' + service + '_details').style.display = (selected === service) ? 'block': 'none';
-  });
+    ['bitly', 'kuttit', 'tly', 'custom'].forEach((service) => {
+        document.querySelector('#' + service + '_details').style.display = selected === service ? 'block' : 'none';
+    });
 
-  // Max canonical URL length makes no sense with no shortening service.
-  document.querySelector('#always_shorten').style.display = (selected === 'none') ? 'none': 'block';
+    // Max canonical URL length makes no sense with no shortening service.
+    document.querySelector('#always_shorten').style.display = selected === 'none' ? 'none' : 'block';
 }
 
 function saveOptions(e) {
-  e.preventDefault();
+    e.preventDefault();
 
-  let toSave = {prefs: {}};
-  Object.keys(options).forEach(id => {
-    toSave['prefs'][id] = document.getElementById(id)[options[id].attr];
-  });
-  browser.storage.local.set(toSave).then(() => {
-    // Indicate that we saved succesfully.
-    let saved = document.querySelector('#saved');
+    let toSave = { prefs: {} };
+    Object.keys(options).forEach((id) => {
+        toSave['prefs'][id] = document.getElementById(id)[options[id].attr];
+    });
+    browser.storage.local.set(toSave).then(() => {
+        // Indicate that we saved succesfully.
+        let saved = document.querySelector('#saved');
 
-    saved.style.display = 'block';
+        saved.style.display = 'block';
 
-    if (savedTimeout) {
-      clearTimeout(savedTimeout);
-    }
-    savedTimeout = setTimeout(() => {
-      saved.style.display = 'none';
-      savedTimeout = null;
-    }, 3000)
-  });
+        if (savedTimeout) {
+            clearTimeout(savedTimeout);
+        }
+        savedTimeout = setTimeout(() => {
+            saved.style.display = 'none';
+            savedTimeout = null;
+        }, 3000);
+    });
 }
 
 document.addEventListener('DOMContentLoaded', init);

--- a/src/data/js/options.js
+++ b/src/data/js/options.js
@@ -1,112 +1,119 @@
 const options = {
-    service: {
-        attr: 'value',
-        def: 'isgd',
-    },
-    bitly_apikey: {
-        attr: 'value',
-        def: '',
-    },
-    kuttit_apikey: {
-        attr: 'value',
-        def: '',
-    },
-    kuttit_domain: {
-        attr: 'value',
-        def: '',
-    },
-    tly_apikey: {
-        attr: 'value',
-        def: '',
-    },
-    tly_domain: {
-        attr: 'value',
-        def: '',
-    },
-    custom_url: {
-        attr: 'value',
-        def: '',
-    },
-    shorten_canonical: {
-        attr: 'value',
-        def: 30,
-    },
-    use_special: {
-        attr: 'checked',
-        def: true,
-    },
-    strip_urm: {
-        attr: 'checked',
-        def: true,
-    },
-    keep_hash: {
-        attr: 'checked',
-        def: false,
-    },
-    notify: {
-        attr: 'checked',
-        def: true,
-    },
-    copy_title: {
-        attr: 'checked',
-        def: false,
-    },
+  service: {
+    attr: 'value',
+    def: 'isgd',
+  },
+  bitly_apikey: {
+    attr: 'value',
+    def: '',
+  },
+  kuttit_apikey: {
+    attr: 'value',
+    def: '',
+  },
+  kuttit_domain: {
+    attr: 'value',
+    def: '',
+  },
+  tly_apikey: {
+    attr: 'value',
+    def: '',
+  },
+  tly_domain: {
+    attr: 'value',
+    def: '',
+  },
+  custom_url: {
+    attr: 'value',
+    def: '',
+  },
+  shorten_canonical: {
+    attr: 'value',
+    def: 30,
+  },
+  use_special: {
+    attr: 'checked',
+    def: true,
+  },
+  strip_urm: {
+    attr: 'checked',
+    def: true,
+  },
+  keep_hash: {
+    attr: 'checked',
+    def: false,
+  },
+  notify: {
+    attr: 'checked',
+    def: true,
+  },
+  copy_title: {
+    attr: 'checked',
+    def: false,
+  },
 };
 let savedTimeout; // Hide saved indicator after a bit.
 
 function init() {
-    // Initialize i18n.
-    document.querySelectorAll('[data-i18n]').forEach((node) => {
-        node.textContent = browser.i18n.getMessage(node.dataset.i18n);
+  // Initialize i18n.
+  document.querySelectorAll('[data-i18n]').forEach((node) => {
+    node.textContent = browser.i18n.getMessage(node.dataset.i18n);
+  });
+
+  // Restore settings.
+  browser.storage.local.get('prefs').then((res) => {
+    let currentPrefs = res['prefs'] || {};
+    Object.keys(options).forEach((id) => {
+      let val =
+        typeof currentPrefs[id] !== 'undefined'
+          ? currentPrefs[id]
+          : options[id].def;
+      document.getElementById(id)[options[id].attr] = val;
     });
 
-    // Restore settings.
-    browser.storage.local.get('prefs').then((res) => {
-        let currentPrefs = res['prefs'] || {};
-        Object.keys(options).forEach((id) => {
-            let val = typeof currentPrefs[id] !== 'undefined' ? currentPrefs[id] : options[id].def;
-            document.getElementById(id)[options[id].attr] = val;
-        });
+    showHideDetails();
+  });
 
-        showHideDetails();
-    });
-
-    document.querySelector('#service').addEventListener('change', showHideDetails);
+  document
+    .querySelector('#service')
+    .addEventListener('change', showHideDetails);
 }
 
 function showHideDetails() {
-    // Show / hide details depending on service selection.
-    let selected = document.querySelector('#service').value;
+  // Show / hide details depending on service selection.
+  let selected = document.querySelector('#service').value;
 
-    ['bitly', 'kuttit', 'tly', 'custom'].forEach((service) => {
-        document.querySelector('#' + service + '_details').style.display = selected === service ? 'block' : 'none';
-    });
+  ['bitly', 'kuttit', 'tly', 'custom'].forEach((service) => {
+    document.querySelector('#' + service + '_details').style.display =
+      selected === service ? 'block' : 'none';
+  });
 
-    // Max canonical URL length makes no sense with no shortening service.
-    document.querySelector('#always_shorten').style.display = selected === 'none' ? 'none' : 'block';
+  // Max canonical URL length makes no sense with no shortening service.
+  document.querySelector('#always_shorten').style.display =
+    selected === 'none' ? 'none' : 'block';
 }
 
 function saveOptions(e) {
-    e.preventDefault();
+  e.preventDefault();
 
-    let toSave = { prefs: {} };
-    Object.keys(options).forEach((id) => {
-        toSave['prefs'][id] = document.getElementById(id)[options[id].attr];
-    });
-    browser.storage.local.set(toSave).then(() => {
-        // Indicate that we saved succesfully.
-        let saved = document.querySelector('#saved');
+  let toSave = { prefs: {} };
+  Object.keys(options).forEach((id) => {
+    toSave['prefs'][id] = document.getElementById(id)[options[id].attr];
+  });
+  browser.storage.local.set(toSave).then(() => {
+    // Indicate that we saved succesfully.
+    let saved = document.querySelector('#saved');
 
-        saved.style.display = 'block';
+    saved.style.display = 'block';
 
-        if (savedTimeout) {
-            clearTimeout(savedTimeout);
-        }
-        savedTimeout = setTimeout(() => {
-            saved.style.display = 'none';
-            savedTimeout = null;
-        }, 3000);
-    });
+    if (savedTimeout) {
+      clearTimeout(savedTimeout);
+    }
+    savedTimeout = setTimeout(() => {
+      saved.style.display = 'none';
+      savedTimeout = null;
+    }, 3000);
+  });
 }
 
 document.addEventListener('DOMContentLoaded', init);

--- a/src/data/js/options.js
+++ b/src/data/js/options.js
@@ -15,6 +15,14 @@ const options = {
     attr: 'value',
     def: ''
   },
+  tly_apikey: {
+    attr: 'value',
+    def: '',
+  },
+  tly_domain: {
+    attr: 'value',
+    def: '',
+  },
   custom_url: {
     attr: 'value',
     def: ''
@@ -71,7 +79,7 @@ function showHideDetails() {
   // Show / hide details depending on service selection.
   let selected = document.querySelector('#service').value;
 
-  ['bitly', 'kuttit', 'custom'].forEach(service => {
+  ['bitly', 'kuttit', 'tly', 'custom'].forEach(service => {
     document.querySelector('#' + service + '_details').style.display = (selected === service) ? 'block': 'none';
   });
 

--- a/src/lib/shortener.js
+++ b/src/lib/shortener.js
@@ -9,261 +9,264 @@ const DEFAULT_SERVICE = 'isgd';
 // variants. Note: return a fetch() promise.
 // Do not forget to add origins to permissions in manifest.
 const serviceUrls = {
-    none: {}, // Placeholder.
+  none: {}, // Placeholder.
 
-    isgd: {
-        url: 'https://is.gd/api.php?longurl=%URL%',
+  isgd: {
+    url: 'https://is.gd/api.php?longurl=%URL%',
+  },
+
+  tinyurl: {
+    url: 'https://tinyurl.com/api-create.php?url=%URL%',
+    force_https: true,
+  },
+
+  cuttly: {
+    request: (url) => {
+      let form = new FormData();
+      form.append('url', url);
+      form.append('domain', 0); // Needed?
+      return fetch('https://cutt.ly/scripts/shortenUrl.php', {
+        method: 'POST',
+        body: form,
+      });
     },
+    result: (response) => response.text(),
+  },
 
-    tinyurl: {
-        url: 'https://tinyurl.com/api-create.php?url=%URL%',
-        force_https: true,
+  vurl: {
+    url: 'https://vurl.com/api.php?url=%URL%',
+    force_https: true,
+  },
+
+  bitly: {
+    // https://dev.bitly.com/v4/#operation/createBitlink
+    request: async (url) => {
+      const ret = await browser.storage.local.get('prefs');
+      const prefs = ret['prefs'] || {};
+      if (!prefs.bitly_apikey) {
+        throw new Error(_('apikey_error'));
+      }
+
+      return fetch('https://api-ssl.bitly.com/v4/shorten', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${prefs.bitly_apikey}`,
+        },
+        body: JSON.stringify({ long_url: url }),
+      });
     },
-
-    cuttly: {
-        request: (url) => {
-            let form = new FormData();
-            form.append('url', url);
-            form.append('domain', 0); // Needed?
-            return fetch('https://cutt.ly/scripts/shortenUrl.php', {
-                method: 'POST',
-                body: form,
-            });
-        },
-        result: (response) => response.text(),
+    result: async (response) => {
+      const res = await response.json();
+      return res['link'];
     },
+    force_https: true,
+  },
 
-    vurl: {
-        url: 'https://vurl.com/api.php?url=%URL%',
-        force_https: true,
+  kuttit: {
+    // https://docs.kutt.it/#tag/links/paths/~1links/post
+    request: async (url) => {
+      const ret = await browser.storage.local.get('prefs');
+      const prefs = ret['prefs'] || {};
+      if (!prefs.kuttit_apikey) {
+        throw new Error(_('apikey_error'));
+      }
+
+      let payload = { target: url };
+      if (prefs['kuttit_domain'] != '') {
+        // Use custom domain only if set.
+        payload['domain'] = prefs['kuttit_domain'];
+      }
+
+      return fetch('https://kutt.it/api/v2/links', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-API-Key': prefs.kuttit_apikey,
+        },
+        body: JSON.stringify(payload),
+      });
     },
-
-    bitly: {
-        // https://dev.bitly.com/v4/#operation/createBitlink
-        request: async (url) => {
-            const ret = await browser.storage.local.get('prefs');
-            const prefs = ret['prefs'] || {};
-            if (!prefs.bitly_apikey) {
-                throw new Error(_('apikey_error'));
-            }
-
-            return fetch('https://api-ssl.bitly.com/v4/shorten', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    Authorization: `Bearer ${prefs.bitly_apikey}`,
-                },
-                body: JSON.stringify({ long_url: url }),
-            });
-        },
-        result: async (response) => {
-            const res = await response.json();
-            return res['link'];
-        },
-        force_https: true,
+    result: async (response) => {
+      const res = await response.json();
+      return res['link'];
     },
+    force_https: true,
+  },
 
-    kuttit: {
-        // https://docs.kutt.it/#tag/links/paths/~1links/post
-        request: async (url) => {
-            const ret = await browser.storage.local.get('prefs');
-            const prefs = ret['prefs'] || {};
-            if (!prefs.kuttit_apikey) {
-                throw new Error(_('apikey_error'));
-            }
+  tly: {
+    // https://t.ly/static_docs/index.html?c=43242#short-link-management
+    request: async (url) => {
+      const ret = await browser.storage.local.get('prefs');
+      const prefs = ret['prefs'] || {};
+      if (!prefs.tly_apikey) {
+        throw new Error(_('apikey_error'));
+      }
 
-            let payload = { target: url };
-            if (prefs['kuttit_domain'] != '') {
-                // Use custom domain only if set.
-                payload['domain'] = prefs['kuttit_domain'];
-            }
+      let headers = {
+        Authorization: `Bearer ${prefs.tly_apikey}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      };
 
-            return fetch('https://kutt.it/api/v2/links', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-API-Key': prefs.kuttit_apikey,
-                },
-                body: JSON.stringify(payload),
-            });
-        },
-        result: async (response) => {
-            const res = await response.json();
-            return res['link'];
-        },
-        force_https: true,
+      let body = {
+        long_url: url,
+      };
+
+      if (prefs['tly_domain']) {
+        // Use custom domain only if set.
+        body['domain'] = prefs['tly_domain'];
+      }
+      return fetch('https://api.t.ly/api/v1/link/shorten', {
+        method: 'POST',
+        headers: headers,
+        body: JSON.stringify(body),
+      });
     },
-
-    tly: {
-        // https://t.ly/static_docs/index.html?c=43242#short-link-management
-        request: async (url) => {
-            const ret = await browser.storage.local.get('prefs');
-            const prefs = ret['prefs'] || {};
-            if (!prefs.tly_apikey) {
-                throw new Error(_('apikey_error'));
-            }
-
-            let headers = {
-                Authorization: `Bearer ${prefs.tly_apikey}`,
-                'Content-Type': 'application/json',
-                Accept: 'application/json',
-            };
-
-            let body = {
-                long_url: url,
-            };
-
-            if (prefs['tly_domain']) {
-                // Use custom domain only if set.
-                body['domain'] = prefs['tly_domain'];
-            }
-            return fetch('https://api.t.ly/api/v1/link/shorten', {
-                method: 'POST',
-                headers: headers,
-                body: JSON.stringify(body),
-            });
-        },
-        result: async (response) => {
-            const res = await response.json();
-            return res['short_url'];
-        },
-        force_https: true,
+    result: async (response) => {
+      const res = await response.json();
+      return res['short_url'];
     },
-    /** Special services: Cannot be chosen manually. **/
-    // Note: No special services implemented at this time after git.io shut down.
+    force_https: true,
+  },
+  /** Special services: Cannot be chosen manually. **/
+  // Note: No special services implemented at this time after git.io shut down.
 };
 
 /** Create a short URL from is.gd, tinyurl, etc. */
 function createShortUrl(url, force_service) {
-    let req;
-    
-    try {
-        // Get shortening service from prefs.
-        return browser.storage.local
-            .get('prefs')
-            .then((ret) => {
-                const prefs = ret['prefs'] || {};
-                let service;
+  let req;
 
-                // Hardcoded special-cased websites can enforce a shortening service.
-                if (prefs.service !== 'none' && force_service) {
-                    service = serviceUrls[force_service];
-                } else {
-                    switch (prefs.service) {
-                        case 'custom':
-                            service = { url: prefs.custom_url };
-                            break;
-                        case 'none':
-                            return url; // Skip shortening altogether.
-                        default:
-                            service = serviceUrls[prefs.service];
-                            service ||= serviceUrls[DEFAULT_SERVICE]; // Fallback to default.
-                            break;
-                    }
-                }
+  try {
+    // Get shortening service from prefs.
+    return browser.storage.local
+      .get('prefs')
+      .then((ret) => {
+        const prefs = ret['prefs'] || {};
+        let service;
 
-                if (service.request) {
-                  req = service.request(url);
-                  
-                } else {
-                    let _uri = service.url.replace('%URL%', encodeURIComponent(url));
-                    req = fetch(_uri);
-                }
+        // Hardcoded special-cased websites can enforce a shortening service.
+        if (prefs.service !== 'none' && force_service) {
+          service = serviceUrls[force_service];
+        } else {
+          switch (prefs.service) {
+            case 'custom':
+              service = { url: prefs.custom_url };
+              break;
+            case 'none':
+              return url; // Skip shortening altogether.
+            default:
+              service = serviceUrls[prefs.service];
+              service ||= serviceUrls[DEFAULT_SERVICE]; // Fallback to default.
+              break;
+          }
+        }
 
-                return req
-                    .then((response) => {
-                        if (response.ok) {
-                            let result = service.result ? service.result(response) : response.text();
-                            return result;
-                        } else {
-                            throw new Error(_('shorten_error'));
-                        }
-                    })
-                    .then((url) => {
-                        // Rewrite shortened URL to https if the service requires it.
-                        if (service.force_https || false) {
-                            let parsedUrl = new URL(url);
-                            parsedUrl.protocol = 'https';
-                            url = parsedUrl.href;
-                        }
-                        return url;
-                    })
-                    .catch((err) => {
-                        notify(err.message);
-                    });
-            })
-            .catch((err) => {
-                console.log(err.message);
-                throw new Error(_('shorten_error'));
-            });
-    } catch (e) {
-        notify(e.message);
-        return false;
-    }
+        if (service.request) {
+          req = service.request(url);
+        } else {
+          let _uri = service.url.replace('%URL%', encodeURIComponent(url));
+          req = fetch(_uri);
+        }
+
+        return req
+          .then((response) => {
+            if (response.ok) {
+              let result = service.result
+                ? service.result(response)
+                : response.text();
+              return result;
+            } else {
+              throw new Error(_('shorten_error'));
+            }
+          })
+          .then((url) => {
+            // Rewrite shortened URL to https if the service requires it.
+            if (service.force_https || false) {
+              let parsedUrl = new URL(url);
+              parsedUrl.protocol = 'https';
+              url = parsedUrl.href;
+            }
+            return url;
+          })
+          .catch((err) => {
+            notify(err.message);
+          });
+      })
+      .catch((err) => {
+        console.log(err.message);
+        throw new Error(_('shorten_error'));
+      });
+  } catch (e) {
+    notify(e.message);
+    return false;
+  }
 }
 
 /** Finalize (notify and copy to clipboard) a detected or generated URL. */
 function finalizeUrl(longUrl, shortUrl, title) {
-    browser.storage.local.get('prefs').then((ret) => {
-        const prefs = ret['prefs'] || {};
-        let copyText;
+  browser.storage.local.get('prefs').then((ret) => {
+    const prefs = ret['prefs'] || {};
+    let copyText;
 
-        // Remove whitespace from final URL.
-        shortUrl = shortUrl.trim();
+    // Remove whitespace from final URL.
+    shortUrl = shortUrl.trim();
 
-        // Add page title, if selected.
-        if (prefs.copy_title === true && title) {
-            copyText = title + ' ' + shortUrl;
-        } else {
-            copyText = shortUrl;
-        }
-        navigator.clipboard.writeText(copyText);
+    // Add page title, if selected.
+    if (prefs.copy_title === true && title) {
+      copyText = title + ' ' + shortUrl;
+    } else {
+      copyText = shortUrl;
+    }
+    navigator.clipboard.writeText(copyText);
 
-        if (prefs.notify !== false) {
-            notify(shortUrl);
-        }
-    });
+    if (prefs.notify !== false) {
+      notify(shortUrl);
+    }
+  });
 }
 
 /** Handle a URL found on the page */
 export default function processUrl(found_url) {
-    let url = found_url['url'];
-    let title = found_url['title'] || '';
-    let hash = found_url['hash'] || '';
+  let url = found_url['url'];
+  let title = found_url['title'] || '';
+  let hash = found_url['hash'] || '';
 
-    browser.storage.local.get('prefs').then((ret) => {
-        const prefs = ret['prefs'] || {};
+  browser.storage.local.get('prefs').then((ret) => {
+    const prefs = ret['prefs'] || {};
 
-        if (prefs.strip_urm !== false || prefs.keep_hash !== false) {
-            let parsedUrl = new URL(url);
+    if (prefs.strip_urm !== false || prefs.keep_hash !== false) {
+      let parsedUrl = new URL(url);
 
-            // Remove UTM tracking codes (from Google Analytics) if present.
-            if (prefs.strip_urm !== false && /[?&]utm_/.test(parsedUrl.search)) {
-                // Find and delete all utm_ tracking parameters.
-                const utm_match = /[?&](utm_[^=]+)=/;
-                while (true) {
-                    let utm_param = utm_match.exec(parsedUrl.search);
-                    if (!utm_param) break;
-                    parsedUrl.searchParams.delete(utm_param[1]);
-                }
-            }
-
-            // Keep URL hash if present.
-            if (prefs.keep_hash !== false && hash) {
-                parsedUrl.hash = hash;
-            }
-
-            url = parsedUrl.toString();
+      // Remove UTM tracking codes (from Google Analytics) if present.
+      if (prefs.strip_urm !== false && /[?&]utm_/.test(parsedUrl.search)) {
+        // Find and delete all utm_ tracking parameters.
+        const utm_match = /[?&](utm_[^=]+)=/;
+        while (true) {
+          let utm_param = utm_match.exec(parsedUrl.search);
+          if (!utm_param) break;
+          parsedUrl.searchParams.delete(utm_param[1]);
         }
+      }
 
-        // Shorten URL if it's not considered "short" or exceeds length limit.
-        if (!found_url['short'] || (prefs.shorten_canonical > 0 && url.length > prefs.shorten_canonical)) {
-            createShortUrl(url, found_url['force_service']).then((result) => {
-                
-                finalizeUrl(url, result, title);
-            });
-        } else {
-            finalizeUrl(null, url, title);
-        }
-    });
+      // Keep URL hash if present.
+      if (prefs.keep_hash !== false && hash) {
+        parsedUrl.hash = hash;
+      }
+
+      url = parsedUrl.toString();
+    }
+
+    // Shorten URL if it's not considered "short" or exceeds length limit.
+    if (
+      !found_url['short'] ||
+      (prefs.shorten_canonical > 0 && url.length > prefs.shorten_canonical)
+    ) {
+      createShortUrl(url, found_url['force_service']).then((result) => {
+        finalizeUrl(url, result, title);
+      });
+    } else {
+      finalizeUrl(null, url, title);
+    }
+  });
 }

--- a/src/lib/shortener.js
+++ b/src/lib/shortener.js
@@ -95,7 +95,7 @@ const serviceUrls = {
   },
 
   tly: {
-    // https://t.ly/static_docs/index.html?c=43242#short-link-management
+    // https://t.ly/static_docs/index.html#short-link-management
     request: async (url) => {
       const ret = await browser.storage.local.get('prefs');
       const prefs = ret['prefs'] || {};

--- a/src/lib/shortener.js
+++ b/src/lib/shortener.js
@@ -93,6 +93,41 @@ const serviceUrls = {
     force_https: true
   },
 
+  tly: {
+    // https://t.ly/static_docs/index.html#short-link-management
+    request: async (url) => {
+      const ret = await browser.storage.local.get('prefs');
+      const prefs = ret['prefs'] || {};
+      if (!prefs.tly_apikey) {
+        throw new Error(_('apikey_error'));
+      }
+
+      let headers = {
+        Authorization: `Bearer ${prefs.tly_apikey}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      };
+
+      let body = {
+        long_url: url,
+      };
+
+      if (prefs['tly_domain'] != '') {
+        // Use custom domain only if set.
+        body['domain'] = prefs['tly_domain'];
+      }
+      return fetch('https://api.t.ly/api/v1/link/shorten', {
+        method: 'POST',
+        headers: headers,
+        body: JSON.stringify(body),
+      });
+    },
+    result: async (response) => {
+      const res = await response.json();
+      return res['short_url'];
+    },
+    force_https: true,
+  },
   /** Special services: Cannot be chosen manually. **/
   // Note: No special services implemented at this time after git.io shut down.
 }

--- a/src/lib/shortener.js
+++ b/src/lib/shortener.js
@@ -9,221 +9,261 @@ const DEFAULT_SERVICE = 'isgd';
 // variants. Note: return a fetch() promise.
 // Do not forget to add origins to permissions in manifest.
 const serviceUrls = {
-  none: {}, // Placeholder.
+    none: {}, // Placeholder.
 
-  isgd: {
-    url: 'https://is.gd/api.php?longurl=%URL%'
-  },
-
-  tinyurl: {
-    url: 'https://tinyurl.com/api-create.php?url=%URL%',
-    force_https: true
-  },
-
-  cuttly: {
-    request: url => {
-      let form = new FormData();
-      form.append('url', url);
-      form.append('domain', 0);  // Needed?
-      return fetch('https://cutt.ly/scripts/shortenUrl.php', {
-        method: 'POST',
-        body: form
-      });
+    isgd: {
+        url: 'https://is.gd/api.php?longurl=%URL%',
     },
-    result: response => response.text()
-  },
 
-  vurl: {
-    url: 'https://vurl.com/api.php?url=%URL%',
-    force_https: true
-  },
+    tinyurl: {
+        url: 'https://tinyurl.com/api-create.php?url=%URL%',
+        force_https: true,
+    },
 
-  bitly: {
-    // https://dev.bitly.com/v4/#operation/createBitlink
-    request: async url => {
-      const ret = await browser.storage.local.get('prefs');
-      const prefs = ret['prefs'] || {};
-      if (!prefs.bitly_apikey) {
-        throw new Error(_('apikey_error'));
-      }
-
-      return fetch('https://api-ssl.bitly.com/v4/shorten', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${prefs.bitly_apikey}`
+    cuttly: {
+        request: (url) => {
+            let form = new FormData();
+            form.append('url', url);
+            form.append('domain', 0); // Needed?
+            return fetch('https://cutt.ly/scripts/shortenUrl.php', {
+                method: 'POST',
+                body: form,
+            });
         },
-        body: JSON.stringify({'long_url': url})
-      });
+        result: (response) => response.text(),
     },
-    result: async response => {
-      const res = await response.json();
-      return res['link'];
+
+    vurl: {
+        url: 'https://vurl.com/api.php?url=%URL%',
+        force_https: true,
     },
-    force_https: true
-  },
 
-  kuttit: {
-    // https://docs.kutt.it/#tag/links/paths/~1links/post
-    request: async url => {
-      const ret = await browser.storage.local.get('prefs');
-      const prefs = ret['prefs'] || {};
-      if (!prefs.kuttit_apikey) {
-        throw new Error(_('apikey_error'));
-      }
+    bitly: {
+        // https://dev.bitly.com/v4/#operation/createBitlink
+        request: async (url) => {
+            const ret = await browser.storage.local.get('prefs');
+            const prefs = ret['prefs'] || {};
+            if (!prefs.bitly_apikey) {
+                throw new Error(_('apikey_error'));
+            }
 
-      let payload = {'target': url};
-      if (prefs['kuttit_domain'] != '') { // Use custom domain only if set.
-        payload['domain'] = prefs['kuttit_domain'];
-      }
-
-      return fetch('https://kutt.it/api/v2/links', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-API-Key': prefs.kuttit_apikey
+            return fetch('https://api-ssl.bitly.com/v4/shorten', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${prefs.bitly_apikey}`,
+                },
+                body: JSON.stringify({ long_url: url }),
+            });
         },
-        body: JSON.stringify(payload)
-      });
+        result: async (response) => {
+            const res = await response.json();
+            return res['link'];
+        },
+        force_https: true,
     },
-    result: async response => {
-      const res = await response.json();
-      return res['link'];
+
+    kuttit: {
+        // https://docs.kutt.it/#tag/links/paths/~1links/post
+        request: async (url) => {
+            const ret = await browser.storage.local.get('prefs');
+            const prefs = ret['prefs'] || {};
+            if (!prefs.kuttit_apikey) {
+                throw new Error(_('apikey_error'));
+            }
+
+            let payload = { target: url };
+            if (prefs['kuttit_domain'] != '') {
+                // Use custom domain only if set.
+                payload['domain'] = prefs['kuttit_domain'];
+            }
+
+            return fetch('https://kutt.it/api/v2/links', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-API-Key': prefs.kuttit_apikey,
+                },
+                body: JSON.stringify(payload),
+            });
+        },
+        result: async (response) => {
+            const res = await response.json();
+            return res['link'];
+        },
+        force_https: true,
     },
-    force_https: true
-  },
 
-  /** Special services: Cannot be chosen manually. **/
-  // Note: No special services implemented at this time after git.io shut down.
-}
+    tly: {
+        // https://t.ly/static_docs/index.html?c=43242#short-link-management
+        request: async (url) => {
+            const ret = await browser.storage.local.get('prefs');
+            const prefs = ret['prefs'] || {};
+            if (!prefs.tly_apikey) {
+                throw new Error(_('apikey_error'));
+            }
 
+            let headers = {
+                Authorization: `Bearer ${prefs.tly_apikey}`,
+                'Content-Type': 'application/json',
+                Accept: 'application/json',
+            };
+
+            let body = {
+                long_url: url,
+            };
+
+            if (prefs['tly_domain']) {
+                // Use custom domain only if set.
+                body['domain'] = prefs['tly_domain'];
+            }
+            return fetch('https://api.t.ly/api/v1/link/shorten', {
+                method: 'POST',
+                headers: headers,
+                body: JSON.stringify(body),
+            });
+        },
+        result: async (response) => {
+            const res = await response.json();
+            return res['short_url'];
+        },
+        force_https: true,
+    },
+    /** Special services: Cannot be chosen manually. **/
+    // Note: No special services implemented at this time after git.io shut down.
+};
 
 /** Create a short URL from is.gd, tinyurl, etc. */
 function createShortUrl(url, force_service) {
-  let req;
+    let req;
+    
+    try {
+        // Get shortening service from prefs.
+        return browser.storage.local
+            .get('prefs')
+            .then((ret) => {
+                const prefs = ret['prefs'] || {};
+                let service;
 
-  try {
-    // Get shortening service from prefs.
-    return browser.storage.local.get('prefs').then(ret => {
-      const prefs = ret['prefs'] || {};
-      let service;
+                // Hardcoded special-cased websites can enforce a shortening service.
+                if (prefs.service !== 'none' && force_service) {
+                    service = serviceUrls[force_service];
+                } else {
+                    switch (prefs.service) {
+                        case 'custom':
+                            service = { url: prefs.custom_url };
+                            break;
+                        case 'none':
+                            return url; // Skip shortening altogether.
+                        default:
+                            service = serviceUrls[prefs.service];
+                            service ||= serviceUrls[DEFAULT_SERVICE]; // Fallback to default.
+                            break;
+                    }
+                }
 
-      // Hardcoded special-cased websites can enforce a shortening service.
-      if (prefs.service !== 'none' && force_service) {
-        service = serviceUrls[force_service];
-      } else {
-        switch (prefs.service) {
-          case 'custom':
-            service = { url: prefs.custom_url };
-            break;
-          case 'none':
-            return url;  // Skip shortening altogether.
-          default:
-            service = serviceUrls[prefs.service];
-            service ||= serviceUrls[DEFAULT_SERVICE];  // Fallback to default.
-            break;
-        }
-      }
+                if (service.request) {
+                  req = service.request(url);
+                  
+                } else {
+                    let _uri = service.url.replace('%URL%', encodeURIComponent(url));
+                    req = fetch(_uri);
+                }
 
-      if (service.request) {
-        req = service.request(url);
-      } else {
-        let _uri = service.url.replace('%URL%', encodeURIComponent(url));
-        req = fetch(_uri);
-      }
-
-      return req.then(response => {
-        if (response.ok) {
-          let result = service.result ? service.result(response) : response.text();
-          return result;
-        } else {
-          throw new Error(_('shorten_error'));
-        }
-      }).then(url => {
-        // Rewrite shortened URL to https if the service requires it.
-        if (service.force_https || false) {
-          let parsedUrl = new URL(url);
-          parsedUrl.protocol = 'https';
-          url = parsedUrl.href;
-        }
-        return url;
-      }).catch(err => {
-        notify(err.message);
-      });
-
-    }).catch(err => {
-      console.log(err.message);
-      throw new Error(_('shorten_error'));
-    });
-
-  } catch (e) {
-    notify(e.message);
-    return false;
-  }
+                return req
+                    .then((response) => {
+                        if (response.ok) {
+                            let result = service.result ? service.result(response) : response.text();
+                            return result;
+                        } else {
+                            throw new Error(_('shorten_error'));
+                        }
+                    })
+                    .then((url) => {
+                        // Rewrite shortened URL to https if the service requires it.
+                        if (service.force_https || false) {
+                            let parsedUrl = new URL(url);
+                            parsedUrl.protocol = 'https';
+                            url = parsedUrl.href;
+                        }
+                        return url;
+                    })
+                    .catch((err) => {
+                        notify(err.message);
+                    });
+            })
+            .catch((err) => {
+                console.log(err.message);
+                throw new Error(_('shorten_error'));
+            });
+    } catch (e) {
+        notify(e.message);
+        return false;
+    }
 }
-
 
 /** Finalize (notify and copy to clipboard) a detected or generated URL. */
 function finalizeUrl(longUrl, shortUrl, title) {
-  browser.storage.local.get('prefs').then(ret => {
-    const prefs = ret['prefs'] || {};
-    let copyText;
+    browser.storage.local.get('prefs').then((ret) => {
+        const prefs = ret['prefs'] || {};
+        let copyText;
 
-    // Remove whitespace from final URL.
-    shortUrl = shortUrl.trim();
+        // Remove whitespace from final URL.
+        shortUrl = shortUrl.trim();
 
-    // Add page title, if selected.
-    if (prefs.copy_title === true && title) {
-      copyText = title + ' ' + shortUrl;
-    } else {
-      copyText = shortUrl;
-    }
-    navigator.clipboard.writeText(copyText);
+        // Add page title, if selected.
+        if (prefs.copy_title === true && title) {
+            copyText = title + ' ' + shortUrl;
+        } else {
+            copyText = shortUrl;
+        }
+        navigator.clipboard.writeText(copyText);
 
-    if (prefs.notify !== false) {
-      notify(shortUrl);
-    }
-  });
+        if (prefs.notify !== false) {
+            notify(shortUrl);
+        }
+    });
 }
-
 
 /** Handle a URL found on the page */
 export default function processUrl(found_url) {
-  let url = found_url['url'];
-  let title = found_url['title'] || '';
-  let hash = found_url['hash'] || '';
+    let url = found_url['url'];
+    let title = found_url['title'] || '';
+    let hash = found_url['hash'] || '';
 
-  browser.storage.local.get('prefs').then(ret => {
-    const prefs = ret['prefs'] || {};
+    browser.storage.local.get('prefs').then((ret) => {
+        const prefs = ret['prefs'] || {};
 
-    if (prefs.strip_urm !== false || prefs.keep_hash !== false) {
-      let parsedUrl = new URL(url);
+        if (prefs.strip_urm !== false || prefs.keep_hash !== false) {
+            let parsedUrl = new URL(url);
 
-      // Remove UTM tracking codes (from Google Analytics) if present.
-      if (prefs.strip_urm !== false && /[?&]utm_/.test(parsedUrl.search)) {
-        // Find and delete all utm_ tracking parameters.
-        const utm_match = /[?&](utm_[^=]+)=/;
-        while (true) {
-          let utm_param = utm_match.exec(parsedUrl.search);
-          if (!utm_param) break;
-          parsedUrl.searchParams.delete(utm_param[1]);
+            // Remove UTM tracking codes (from Google Analytics) if present.
+            if (prefs.strip_urm !== false && /[?&]utm_/.test(parsedUrl.search)) {
+                // Find and delete all utm_ tracking parameters.
+                const utm_match = /[?&](utm_[^=]+)=/;
+                while (true) {
+                    let utm_param = utm_match.exec(parsedUrl.search);
+                    if (!utm_param) break;
+                    parsedUrl.searchParams.delete(utm_param[1]);
+                }
+            }
+
+            // Keep URL hash if present.
+            if (prefs.keep_hash !== false && hash) {
+                parsedUrl.hash = hash;
+            }
+
+            url = parsedUrl.toString();
         }
-      }
 
-      // Keep URL hash if present.
-      if (prefs.keep_hash !== false && hash) {
-        parsedUrl.hash = hash;
-      }
-
-      url = parsedUrl.toString();
-    }
-
-    // Shorten URL if it's not considered "short" or exceeds length limit.
-    if (!found_url['short'] || (prefs.shorten_canonical > 0 && url.length > prefs.shorten_canonical)) {
-      createShortUrl(url, found_url['force_service'])
-      .then(result => finalizeUrl(url, result, title));
-    } else {
-      finalizeUrl(null, url, title);
-    }
-  });
+        // Shorten URL if it's not considered "short" or exceeds length limit.
+        if (!found_url['short'] || (prefs.shorten_canonical > 0 && url.length > prefs.shorten_canonical)) {
+            createShortUrl(url, found_url['force_service']).then((result) => {
+                
+                finalizeUrl(url, result, title);
+            });
+        } else {
+            finalizeUrl(null, url, title);
+        }
+    });
 }

--- a/src/lib/shortener.js
+++ b/src/lib/shortener.js
@@ -113,7 +113,7 @@ const serviceUrls = {
         long_url: url,
       };
 
-      if (prefs['tly_domain']) {
+      if (prefs['tly_domain'] != '') {
         // Use custom domain only if set.
         body['domain'] = prefs['tly_domain'];
       }


### PR DESCRIPTION
## Feature: Add t.ly URL Shortener Support

This Pull Request introduces the `t.ly` shortener service as an option for generating short URLs.

- **Service Implemented:** `t.ly`
- **Reasoning:** `t.ly` is a reliable, fast, and free shortener service that provides another good option for users of this extension.

## Bug Fix / Maintenance

- **Fixed locales messages:** Corrected some existing locale messages to improve accuracy.

## Note for Maintainer (Code Formatting)

I use the Prettier code formatter locally, and I inadvertently formatted the code in some files (potentially due to running an auto-format on save).

I sincerely apologise for the unnecessary diff in the PR history. The core changes are strictly for the `t.ly` feature and the locale fixes.

If the formatting changes are not desired, please let me know, and I can try to revert them or squash the relevant commits before merging.